### PR TITLE
[FEAT] 프로필 등록 페이지 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ dist-ssr
 *.sw?
 
 .vercel
+.env

--- a/src/api/create-profile.ts
+++ b/src/api/create-profile.ts
@@ -1,0 +1,20 @@
+import ky from "ky";
+import { UserProfileType, UserProfileResType, UserApiResType } from "../types/api-types/UserType";
+const apiUrl = import.meta.env.SERVER_URL;
+
+export const createProfile = async (userData: UserProfileType) => {
+  try {
+    const response = await ky.post(`${apiUrl}/users`, {
+      json: userData,
+      credentials: "include",
+    });
+
+    const result: UserApiResType<UserProfileResType> = await response.json();
+
+    if (result.success) return result.data;
+    else return result.error;
+  } catch (error) {
+    console.log(error);
+    return undefined;
+  }
+};

--- a/src/api/get-job-group.ts
+++ b/src/api/get-job-group.ts
@@ -1,0 +1,16 @@
+import ky from "ky";
+import { JobGroupApiResType } from "../types/api-types/JobGroup";
+const apiUrl = import.meta.env.SERVER_URL;
+
+export const getJobGroup = async () => {
+  try {
+    const response = await ky.get(`${apiUrl}/job-group`, { credentials: "include" });
+    const result: JobGroupApiResType = await response.json();
+
+    if (result.success) return result.data;
+    else return result.error;
+  } catch (error) {
+    console.log(error);
+    return undefined;
+  }
+};

--- a/src/api/get-tech-stacks.ts
+++ b/src/api/get-tech-stacks.ts
@@ -1,0 +1,16 @@
+import ky from "ky";
+import { ITechStackType, TechStackApiResType } from "../types/api-types/TechStackType";
+const apiUrl = import.meta.env.SERVER_URL;
+
+export const getTechStacks = async () => {
+  try {
+    const response = await ky.get(`${apiUrl}/techstacks`, { credentials: "include" });
+    const result: TechStackApiResType<ITechStackType> = await response.json();
+
+    if (result.success) return result.data;
+    else return result.error;
+  } catch (error) {
+    console.log(error);
+    return undefined;
+  }
+};

--- a/src/api/get-user-profile.ts
+++ b/src/api/get-user-profile.ts
@@ -1,0 +1,16 @@
+import ky from "ky";
+import { UserProfileResType, UserApiResType } from "../types/api-types/UserType";
+const apiUrl = import.meta.env.SERVER_URL;
+
+export const getUserProfile = async (userId: string) => {
+  try {
+    const response = await ky.get(`${apiUrl}/users/user/${userId}`, { credentials: "include" });
+    const result: UserApiResType<UserProfileResType> = await response.json();
+
+    if (result.success) return result.data;
+    else return result.error;
+  } catch (error) {
+    console.log(error);
+    return undefined;
+  }
+};

--- a/src/api/upload-single-img.ts
+++ b/src/api/upload-single-img.ts
@@ -1,0 +1,23 @@
+import ky from "ky";
+import { PortfolioThumbnailResType } from "../types/api-types/PortfolioType";
+const apiUrl = import.meta.env.VITE_SERVER_URL;
+
+export const uploadSingleImg = async (img: File) => {
+  const formData = new FormData();
+  formData.append("image", img);
+
+  try {
+    const response = await ky.post(`${apiUrl}/api/portfolios/upload`, {
+      body: formData,
+      credentials: "include",
+    });
+
+    const result: PortfolioThumbnailResType = await response.json();
+
+    if (result.success) return result.data?.url;
+    else return result.error;
+  } catch (error) {
+    console.log(error);
+    return undefined;
+  }
+};

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Job } from "../../types/job";
 import { DropdownContainer, Input, Ul, Li, InputWrapper } from "./Dropdown.styles";
 import { ITechStackType } from "../../types/api-types/TechStackType";
+import { JobGroupType } from "../../types/api-types/JobGroup";
 
 export interface DropdownType {
   isOpen: boolean;
-  items: ITechStackType[] | Job[];
+  items: ITechStackType[] | JobGroupType[];
   position: { x: number; y: number };
   placeholder: string;
-  onSelect: (item: ITechStackType | Job) => void;
+  onSelect: (item: ITechStackType | JobGroupType) => void;
 }
 
 const Dropdown: React.FC<DropdownType> = ({ isOpen, items, position, placeholder, onSelect }) => {
@@ -23,8 +23,8 @@ const Dropdown: React.FC<DropdownType> = ({ isOpen, items, position, placeholder
     if ("skill" in item) {
       return item.skill.toLowerCase().includes(inputValue.toLowerCase());
     }
-    if ("name" in item) {
-      return item.name.toLowerCase().includes(inputValue.toLowerCase());
+    if ("job" in item) {
+      return item.job.toLowerCase().includes(inputValue.toLowerCase());
     }
   });
 
@@ -41,8 +41,8 @@ const Dropdown: React.FC<DropdownType> = ({ isOpen, items, position, placeholder
       </InputWrapper>
       <Ul>
         {filteredItems.map(item => (
-          <Li key={"skill" in item ? item.skill : item.name} onClick={() => onSelect(item)}>
-            {"skill" in item ? item.skill : item.name}
+          <Li key={"skill" in item ? item.skill : item.job} onClick={() => onSelect(item)}>
+            {"skill" in item ? item.skill : item.job}
           </Li>
         ))}
       </Ul>

--- a/src/components/Dropdown/DropdownWithBtn.tsx
+++ b/src/components/Dropdown/DropdownWithBtn.tsx
@@ -1,12 +1,12 @@
 import { useRef, useState, useEffect } from "react";
 import Dropdown from "./Dropdown";
 import { DropBtn } from "./Dropdown.styles";
-import { Job } from "../../types/job";
 import { ITechStackType } from "../../types/api-types/TechStackType";
+import { JobGroupType } from "../../types/api-types/JobGroup";
 
 interface DropDownWithBtnProps {
   name?: string;
-  items: ITechStackType[] | Job[];
+  items: ITechStackType[] | JobGroupType[];
   placeholder: string;
 }
 

--- a/src/data/dummyData.ts
+++ b/src/data/dummyData.ts
@@ -1,5 +1,5 @@
-import { Job } from "../types/job";
 import { ITechStackType } from "../types/api-types/TechStackType";
+import { JobGroupType } from "../types/api-types/JobGroup";
 
 export const dummyTags = [
   {
@@ -199,25 +199,24 @@ export const techStacks: ITechStackType[] = [
   },
 ];
 
-export const jobs: Job[] = [
-  { jobCode: -1, name: "Frontend Developer" },
-  { jobCode: 0, name: "Backend Developer" },
-  { jobCode: 1, name: "Software Engineer" },
-  { jobCode: 1, name: "Software Engineer" },
-  { jobCode: 2, name: "Data Scientist" },
-  { jobCode: 3, name: "Product Manager" },
-  { jobCode: 4, name: "UX/UI Designer" },
-  { jobCode: 5, name: "QA Engineer" },
-  { jobCode: 6, name: "DevOps Engineer" },
-  { jobCode: 7, name: "System Administrator" },
-  { jobCode: 8, name: "Database Administrator" },
-  { jobCode: 9, name: "Network Engineer" },
-  { jobCode: 10, name: "Business Analyst" },
-  { jobCode: 11, name: "Sales Representative" },
-  { jobCode: 12, name: "Content Writer" },
-  { jobCode: 13, name: "Marketing Specialist" },
-  { jobCode: 14, name: "SEO Specialist" },
-  { jobCode: 15, name: "Technical Support Specialist" },
+export const jobGroups: JobGroupType[] = [
+  { _id: "job-1", job: "Frontend Developer" },
+  { _id: "job-2", job: "Backend Developer" },
+  { _id: "job-3", job: "Software Engineer" },
+  { _id: "job-4", job: "Data Scientist" },
+  { _id: "job-5", job: "Product Manager" },
+  { _id: "job-6", job: "UX/UI Designer" },
+  { _id: "job-7", job: "QA Engineer" },
+  { _id: "job-8", job: "DevOps Engineer" },
+  { _id: "job-9", job: "System Administrator" },
+  { _id: "job-10", job: "Database Administrator" },
+  { _id: "job-11", job: "Network Engineer" },
+  { _id: "job-12", job: "Business Analyst" },
+  { _id: "job-13", job: "Sales Representative" },
+  { _id: "job-14", job: "Content Writer" },
+  { _id: "job-15", job: "Marketing Specialist" },
+  { _id: "job-16", job: "SEO Specialist" },
+  { _id: "job-17", job: "Technical Support Specialist" },
 ];
 
 export const dummyTags2 = [

--- a/src/pages/EditPortfolio/EditPortfolioPage.tsx
+++ b/src/pages/EditPortfolio/EditPortfolioPage.tsx
@@ -6,7 +6,7 @@ import TechStack from "../../components/TechStack/TechStack";
 import ThumbnailInput from "./ThumbnailInput/ThumbnailInput";
 import DropdownWithBtn from "../../components/Dropdown/DropdownWithBtn";
 import MyCKEditor from "./MyCKEditor/MyCKEditor";
-import { techStacks, jobs, dummyTags, dummyTechStacks } from "../../data/dummyData";
+import { techStacks, jobGroups, dummyTags, dummyTechStacks } from "../../data/dummyData";
 import TagInput from "./TagInput/TagInput";
 
 const EditPortfolioPage = () => {
@@ -72,7 +72,7 @@ const EditPortfolioPage = () => {
           {/* <TechStackSwiper items={dummyTechStacks} /> */}
         </div>
         <div className="input big">
-          <DropdownWithBtn name="직군" items={jobs} placeholder="직군을 입력해주세요." />
+          <DropdownWithBtn name="직군" items={jobGroups} placeholder="직군을 입력해주세요." />
           {dummyTags.map(tag => (
             <Tag key={tag.content} {...tag} />
           ))}

--- a/src/pages/EditProfile/EditProfilePage.styles.ts
+++ b/src/pages/EditProfile/EditProfilePage.styles.ts
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import { SwiperSlide } from "swiper/react";
 
 export const CenteredContainer = styled.div`
   display: flex;

--- a/src/pages/EditProfile/EditProfilePage.styles.ts
+++ b/src/pages/EditProfile/EditProfilePage.styles.ts
@@ -11,6 +11,11 @@ export const CenteredContainer = styled.div`
 export const EditProfilePageContainer = styled.div`
   width: 1100px;
   margin: auto;
+
+  span {
+    display: inline-block;
+    text-align: center;
+  }
 `;
 
 export const H2 = styled.h2`
@@ -56,7 +61,9 @@ export const RightUserInfo = styled.div`
   flex: 6;
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   gap: ${({ theme }) => theme.PADDINGS.X_LARGE};
+  width: 60%;
 `;
 
 export const SelectContainer = styled.div`
@@ -64,33 +71,25 @@ export const SelectContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: ${({ theme }) => theme.PADDINGS.X_LARGE};
+  gap: ${({ theme }) => theme.PADDINGS.X_SMALL};
 `;
 
 export const SelectWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: ${({ theme }) => theme.PADDINGS.SMALL};
-
-  p {
-    font-size: ${({ theme }) => theme.FONT_SIZE.HEADING3};
-    font-weight: ${({ theme }) => theme.FONT_WEIGHT.THICK};
-    color: ${({ theme }) => theme.COLORS.MAIN_BLACK};
-  }
-
-  button.select-btn {
-  }
+  justify-content: flex-start;
+  gap: ${({ theme }) => theme.PADDINGS.X_SMALL};
+  height: 40%;
 
   div {
     display: flex;
-    gap: ${({ theme }) => theme.PADDINGS.X_SMALL};
-    max-width: 700px;
-    overflow: hidden;
+    flex-wrap: wrap;
+    gap: ${({ theme }) => `calc(${theme.PADDINGS.X_SMALL} / 3)`};
   }
 `;
 
 export const SelectBtn = styled.button`
-  width: 90px;
+  width: 140px;
   height: 42px;
   border-radius: ${({ theme }) => theme.BORDER_RADIUS.HALF_CIRCLE};
   background-color: ${({ theme }) => theme.COLORS.LIGHTGREEN_GRAY};
@@ -98,36 +97,31 @@ export const SelectBtn = styled.button`
   padding: ${({ theme }) => theme.PADDINGS.X_SMALL} ${({ theme }) => theme.PADDINGS.SMALL};
   cursor: pointer;
   position: relative;
+  font-size: ${({ theme }) => theme.FONT_SIZE.CONTENT};
+  font-weight: ${({ theme }) => theme.FONT_WEIGHT.THICK};
 
   &::after {
     content: "";
     position: absolute;
-    top: 50%;
-    right: 10px;
+    top: 40%;
+    left: 8px;
     transform: translateY(-50%);
+    transform: rotate(90deg);
     border-left: 8px solid transparent;
     border-right: 8px solid transparent;
     border-top: 10px solid ${({ theme }) => theme.COLORS.MAIN_BLACK};
   }
 `;
 
-export const StyledSwiperSlide = styled(SwiperSlide)`
-  width: fit-content;
-  display: flex;
-`;
-
-export const TechStackWrapper = styled.div`
-  pointer-events: none;
-`;
-
 export const Intro = styled.textarea`
-  height: 40%;
+  height: 35%;
   width: 100%;
   padding: ${({ theme }) => theme.PADDINGS.X_SMALL};
   border-radius: ${({ theme }) => theme.BORDER_RADIUS.DEFAULT};
   border: 1px solid ${({ theme }) => theme.COLORS.MAIN_GRAY};
   color: ${({ theme }) => theme.COLORS.MAIN_BLACK};
   font-size: ${({ theme }) => theme.FONT_SIZE.CONTENT};
+  resize: none;
 
   &:focus {
     outline: 1px solid ${({ theme }) => theme.COLORS.MAIN_GREEN};

--- a/src/pages/EditProfile/EditProfilePage.styles.ts
+++ b/src/pages/EditProfile/EditProfilePage.styles.ts
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { SwiperSlide } from "swiper/react";
 
 export const CenteredContainer = styled.div`
   display: flex;
@@ -83,6 +84,8 @@ export const SelectWrapper = styled.div`
   div {
     display: flex;
     gap: ${({ theme }) => theme.PADDINGS.X_SMALL};
+    max-width: 700px;
+    overflow: hidden;
   }
 `;
 
@@ -106,6 +109,15 @@ export const SelectBtn = styled.button`
     border-right: 8px solid transparent;
     border-top: 10px solid ${({ theme }) => theme.COLORS.MAIN_BLACK};
   }
+`;
+
+export const StyledSwiperSlide = styled(SwiperSlide)`
+  width: fit-content;
+  display: flex;
+`;
+
+export const TechStackWrapper = styled.div`
+  pointer-events: none;
 `;
 
 export const Intro = styled.textarea`

--- a/src/pages/EditProfile/EditProfilePage.tsx
+++ b/src/pages/EditProfile/EditProfilePage.tsx
@@ -26,6 +26,12 @@ import { JobGroupType } from "../../types/api-types/JobGroup";
 import { uploadSingleImg } from "../../api/upload-single-img";
 import { createProfile } from "../../api/create-profile";
 
+/**
+ * todo
+ * - 로그인 페이지에서 로그인이 되면 유저 상태가 전역 상태로 저장
+ * - useEffect 훅을 통해 유저정보가 있다면 미리 채워넣음
+ */
+
 const EditProfilePage: React.FC = () => {
   const [profileImage, setProfileImage] = useState<File | null>(null);
   const [previewProfileImg, setPreviewProfileImg] = useState<string | null>(null);
@@ -48,6 +54,18 @@ const EditProfilePage: React.FC = () => {
   const techStackBtnRef = useRef<HTMLButtonElement>(null);
   const jobBtnRef = useRef<HTMLButtonElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isModalOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    } else {
+      document.removeEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isModalOpen]);
 
   const handleTechStackClick = () => {
     if (techStackBtnRef.current) {
@@ -87,18 +105,6 @@ const EditProfilePage: React.FC = () => {
       setIsModalOpen(false);
     }
   };
-
-  useEffect(() => {
-    if (isModalOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-    } else {
-      document.removeEventListener("mousedown", handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [isModalOpen]);
 
   const handleJobSelect = (job: JobGroupType) => {
     setSelectedJob(job);

--- a/src/pages/EditProfile/EditProfilePage.tsx
+++ b/src/pages/EditProfile/EditProfilePage.tsx
@@ -10,8 +10,6 @@ import {
   SelectContainer,
   SelectWrapper,
   SelectBtn,
-  StyledSwiperSlide,
-  TechStackWrapper,
   Intro,
   SubmitBtn,
 } from "./EditProfilePage.styles";
@@ -25,12 +23,10 @@ import TechStack from "../../components/TechStack/TechStack";
 import { ITechStackType } from "../../types/api-types/TechStackType";
 import { UserProfileType } from "../../types/api-types/UserType";
 import { JobGroupType } from "../../types/api-types/JobGroup";
-import { Swiper } from "swiper/react";
-import "swiper/swiper-bundle.css";
 
 /**
  * todo
- * 기술스택 스와이퍼
+ * 직무, 기술스택 선택 박스
  */
 
 const EditProfilePage: React.FC = () => {
@@ -121,6 +117,8 @@ const EditProfilePage: React.FC = () => {
 
   const handleSubmit = async () => {};
 
+  console.log(selectedTechStacks);
+
   return (
     <CenteredContainer>
       <EditProfilePageContainer>
@@ -142,31 +140,27 @@ const EditProfilePage: React.FC = () => {
           <RightUserInfo>
             <SelectContainer>
               <SelectWrapper>
-                <p>직무 선택</p>
+                <SelectBtn ref={jobBtnRef} onClick={handleJobClick}>
+                  직무
+                </SelectBtn>
                 <div>
-                  <SelectBtn ref={jobBtnRef} onClick={handleJobClick}></SelectBtn>
                   {selectedJob && (
                     <Tag content={selectedJob.job} onClick={() => setSelectedJob(null)} />
                   )}
                 </div>
               </SelectWrapper>
               <SelectWrapper>
-                <p>기술스택 선택</p>
+                <SelectBtn ref={techStackBtnRef} onClick={handleTechStackClick}>
+                  기술스택
+                </SelectBtn>
                 <div>
-                  <SelectBtn ref={techStackBtnRef} onClick={handleTechStackClick}></SelectBtn>
-                  <Swiper slidesPerView="auto" spaceBetween={10}>
-                    <StyledSwiperSlide>
-                      {selectedTechStacks.map(stack => (
-                        <TechStackWrapper>
-                          <TechStack
-                            key={stack.skill}
-                            content={stack}
-                            onClick={() => handleTechStackSelect(stack)}
-                          />
-                        </TechStackWrapper>
-                      ))}
-                    </StyledSwiperSlide>
-                  </Swiper>
+                  {selectedTechStacks.map(stack => (
+                    <TechStack
+                      key={stack.skill}
+                      content={stack}
+                      onClick={() => handleTechStackSelect(stack)}
+                    />
+                  ))}
                 </div>
               </SelectWrapper>
             </SelectContainer>
@@ -184,7 +178,7 @@ const EditProfilePage: React.FC = () => {
           <Dropdown
             isOpen={isTechStackOpen}
             items={techStacks}
-            position={{ x: techStackPosition.x, y: techStackPosition.y + 10 }}
+            position={{ x: techStackPosition.x - 250, y: techStackPosition.y - 40 }}
             placeholder="기술스택을 입력하세요"
             onSelect={item => {
               if ("skill" in item) handleTechStackSelect(item);
@@ -195,7 +189,7 @@ const EditProfilePage: React.FC = () => {
           <Dropdown
             isOpen={isJobOpen}
             items={jobGroups}
-            position={{ x: jobPosition.x, y: jobPosition.y + 10 }}
+            position={{ x: jobPosition.x - 250, y: jobPosition.y - 40 }}
             placeholder="직군을 입력하세요"
             onSelect={item => {
               if ("job" in item) handleJobSelect(item);

--- a/src/pages/EditProfile/EditProfilePage.tsx
+++ b/src/pages/EditProfile/EditProfilePage.tsx
@@ -17,12 +17,30 @@ import Button from "../../components/Button/Button";
 import Dropdown from "../../components/Dropdown/Dropdown";
 import ProfileImage from "./ProfileImage";
 import UserInfoInputs from "./UserInfoInputs";
-import { techStacks, jobs, dummyTags, dummyTechStacks } from "../../data/dummyData";
+import { techStacks, jobGroups } from "../../data/dummyData";
 import Tag from "../../components/Tag/Tag";
 import TechStack from "../../components/TechStack/TechStack";
+import { ITechStackType } from "../../types/api-types/TechStackType";
+import { UserProfileType } from "../../types/api-types/UserType";
+import { JobGroupType } from "../../types/api-types/JobGroup";
+
+/**
+ * todo
+ * 기술스택 스와이퍼
+ */
 
 const EditProfilePage: React.FC = () => {
   const [profileImage, setProfileImage] = useState<string | null>(null);
+  const [userInfo, setUserInfo] = useState({
+    email: "",
+    mobile: "",
+    github: "",
+    instagram: "",
+    blog: "",
+  });
+  const [intro, setIntro] = useState("");
+  const [selectedJob, setSelectedJob] = useState<JobGroupType | null>(null);
+  const [selectedTechStacks, setSelectedTechStacks] = useState<ITechStackType[]>([]);
   const [isTechStackOpen, setIsTechStackOpen] = useState(false);
   const [isJobOpen, setIsJobOpen] = useState(false);
   const [techStackPosition, setTechStackPosition] = useState({ x: 0, y: 0 });
@@ -82,6 +100,23 @@ const EditProfilePage: React.FC = () => {
     };
   }, [isModalOpen]);
 
+  const handleJobSelect = (job: JobGroupType) => {
+    setSelectedJob(job);
+    setIsJobOpen(false);
+  };
+
+  const handleTechStackSelect = (techStack: ITechStackType) => {
+    setSelectedTechStacks(prev => {
+      if (prev.includes(techStack)) {
+        return prev.filter(stack => stack !== techStack);
+      } else {
+        return [...prev, techStack];
+      }
+    });
+  };
+
+  const handleSubmit = async () => {};
+
   return (
     <CenteredContainer>
       <EditProfilePageContainer>
@@ -97,7 +132,7 @@ const EditProfilePage: React.FC = () => {
               ref={modalRef}
             />
             <UserInfoInputWrapper>
-              <UserInfoInputs />
+              <UserInfoInputs onChange={setUserInfo} />
             </UserInfoInputWrapper>
           </LeftUserInfo>
           <RightUserInfo>
@@ -106,29 +141,33 @@ const EditProfilePage: React.FC = () => {
                 <p>직무 선택</p>
                 <div>
                   <SelectBtn ref={jobBtnRef} onClick={handleJobClick}></SelectBtn>
-                  {dummyTags.map(tag => (
-                    <Tag key={tag.content} {...tag} />
-                  ))}
+                  {selectedJob && (
+                    <Tag content={selectedJob.job} onClick={() => setSelectedJob(null)} />
+                  )}
                 </div>
               </SelectWrapper>
               <SelectWrapper>
                 <p>기술스택 선택</p>
                 <div>
                   <SelectBtn ref={techStackBtnRef} onClick={handleTechStackClick}></SelectBtn>
-                  {dummyTechStacks.map(techStack => (
+                  {selectedTechStacks.map(stack => (
                     <TechStack
-                      key={techStack.skill}
-                      content={{ ...techStack }}
-                      onClick={() => {}}
+                      key={stack.skill}
+                      content={stack}
+                      onClick={() => handleTechStackSelect(stack)}
                     />
                   ))}
                 </div>
               </SelectWrapper>
             </SelectContainer>
-            <Intro placeholder="자기소개를 입력해주세요"></Intro>
+            <Intro
+              placeholder="자기소개를 입력해주세요"
+              value={intro}
+              onChange={e => setIntro(e.target.value)}
+            />
           </RightUserInfo>
         </EditProfileWrapper>
-        <SubmitBtn>
+        <SubmitBtn onClick={handleSubmit}>
           <Button text="등록" colorType={3} />
         </SubmitBtn>
         {isTechStackOpen && (
@@ -137,16 +176,20 @@ const EditProfilePage: React.FC = () => {
             items={techStacks}
             position={{ x: techStackPosition.x, y: techStackPosition.y + 10 }}
             placeholder="기술스택을 입력하세요"
-            onSelect={item => console.log(item)}
+            onSelect={item => {
+              if ("skill" in item) handleTechStackSelect(item);
+            }}
           />
         )}
         {isJobOpen && (
           <Dropdown
             isOpen={isJobOpen}
-            items={jobs}
+            items={jobGroups}
             position={{ x: jobPosition.x, y: jobPosition.y + 10 }}
             placeholder="직군을 입력하세요"
-            onSelect={item => console.log(item)}
+            onSelect={item => {
+              if ("job" in item) handleJobSelect(item);
+            }}
           />
         )}
       </EditProfilePageContainer>

--- a/src/pages/EditProfile/EditProfilePage.tsx
+++ b/src/pages/EditProfile/EditProfilePage.tsx
@@ -23,14 +23,12 @@ import TechStack from "../../components/TechStack/TechStack";
 import { ITechStackType } from "../../types/api-types/TechStackType";
 import { UserProfileType } from "../../types/api-types/UserType";
 import { JobGroupType } from "../../types/api-types/JobGroup";
-
-/**
- * todo
- * 직무, 기술스택 선택 박스
- */
+import { uploadSingleImg } from "../../api/upload-single-img";
+import { createProfile } from "../../api/create-profile";
 
 const EditProfilePage: React.FC = () => {
-  const [profileImage, setProfileImage] = useState<string | null>(null);
+  const [profileImage, setProfileImage] = useState<File | null>(null);
+  const [previewProfileImg, setPreviewProfileImg] = useState<string | null>(null);
   const [userInfo, setUserInfo] = useState({
     email: "",
     mobile: "",
@@ -70,9 +68,10 @@ const EditProfilePage: React.FC = () => {
   const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) {
+      setProfileImage(file);
       const reader = new FileReader();
       reader.onloadend = () => {
-        setProfileImage(reader.result as string);
+        setPreviewProfileImg(reader.result as string);
       };
       reader.readAsDataURL(file);
     }
@@ -80,6 +79,7 @@ const EditProfilePage: React.FC = () => {
 
   const handleSetDefaultProfile = () => {
     setProfileImage(null);
+    setPreviewProfileImg(null);
   };
 
   const handleClickOutside = (event: MouseEvent) => {
@@ -115,9 +115,25 @@ const EditProfilePage: React.FC = () => {
     });
   };
 
-  const handleSubmit = async () => {};
+  const handleSubmit = async () => {
+    if (!profileImage) {
+      return;
+    }
 
-  console.log(selectedTechStacks);
+    const profileImgUrl = await uploadSingleImg(profileImage);
+    const userProfileData: UserProfileType = {
+      email: userInfo.email,
+      intro: intro,
+      phoneNumber: userInfo.mobile,
+      links: [userInfo.github, userInfo.instagram, userInfo.blog],
+      techStack: selectedTechStacks,
+      jobGroup: selectedJob?.job!,
+      profileImage: profileImgUrl!,
+    };
+
+    const response = await createProfile(userProfileData);
+    console.log(response);
+  };
 
   return (
     <CenteredContainer>
@@ -126,7 +142,7 @@ const EditProfilePage: React.FC = () => {
         <EditProfileWrapper>
           <LeftUserInfo>
             <ProfileImage
-              imageUrl={profileImage}
+              imageUrl={previewProfileImg}
               onImageChange={handleImageChange}
               onSetDefaultProfile={handleSetDefaultProfile}
               isModalOpen={isModalOpen}

--- a/src/pages/EditProfile/EditProfilePage.tsx
+++ b/src/pages/EditProfile/EditProfilePage.tsx
@@ -10,6 +10,8 @@ import {
   SelectContainer,
   SelectWrapper,
   SelectBtn,
+  StyledSwiperSlide,
+  TechStackWrapper,
   Intro,
   SubmitBtn,
 } from "./EditProfilePage.styles";
@@ -23,6 +25,8 @@ import TechStack from "../../components/TechStack/TechStack";
 import { ITechStackType } from "../../types/api-types/TechStackType";
 import { UserProfileType } from "../../types/api-types/UserType";
 import { JobGroupType } from "../../types/api-types/JobGroup";
+import { Swiper } from "swiper/react";
+import "swiper/swiper-bundle.css";
 
 /**
  * todo
@@ -150,13 +154,19 @@ const EditProfilePage: React.FC = () => {
                 <p>기술스택 선택</p>
                 <div>
                   <SelectBtn ref={techStackBtnRef} onClick={handleTechStackClick}></SelectBtn>
-                  {selectedTechStacks.map(stack => (
-                    <TechStack
-                      key={stack.skill}
-                      content={stack}
-                      onClick={() => handleTechStackSelect(stack)}
-                    />
-                  ))}
+                  <Swiper slidesPerView="auto" spaceBetween={10}>
+                    <StyledSwiperSlide>
+                      {selectedTechStacks.map(stack => (
+                        <TechStackWrapper>
+                          <TechStack
+                            key={stack.skill}
+                            content={stack}
+                            onClick={() => handleTechStackSelect(stack)}
+                          />
+                        </TechStackWrapper>
+                      ))}
+                    </StyledSwiperSlide>
+                  </Swiper>
                 </div>
               </SelectWrapper>
             </SelectContainer>

--- a/src/pages/EditProfile/InfoInput.styles.ts
+++ b/src/pages/EditProfile/InfoInput.styles.ts
@@ -17,15 +17,15 @@ export const IconWrapper = styled.div`
   }
 `;
 
-export const Input = styled.input`
+export const Input = styled.input<{ error?: boolean }>`
   width: 100%;
   padding: ${({ theme }) => `calc(${theme.PADDINGS.X_SMALL} / 2)`};
   border-radius: ${({ theme }) => theme.BORDER_RADIUS.DEFAULT};
-  border: 1px solid ${({ theme }) => theme.COLORS.MAIN_GRAY};
+  border: 1px solid ${({ error, theme }) => (error ? theme.COLORS.RED : theme.COLORS.MAIN_GRAY)};
   color: ${({ theme }) => theme.COLORS.MAIN_BLACK};
   font-size: ${({ theme }) => theme.FONT_SIZE.CONTENT};
 
   &:focus {
-    outline: 1px solid ${({ theme }) => theme.COLORS.MAIN_GREEN};
+    outline: 1px solid ${({ error, theme }) => (error ? theme.COLORS.RED : theme.COLORS.MAIN_GREEN)};
   }
 `;

--- a/src/pages/EditProfile/InfoInput.tsx
+++ b/src/pages/EditProfile/InfoInput.tsx
@@ -4,14 +4,17 @@ import { UserInfoInput, IconWrapper, Input } from "./InfoInput.styles";
 interface UserInfoInputProps {
   icon: string;
   placeholder: string;
+  value: string;
+  error?: boolean;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const InfoInput: React.FC<UserInfoInputProps> = ({ icon, placeholder }) => (
+const InfoInput: React.FC<UserInfoInputProps> = ({ icon, placeholder, value, error, onChange }) => (
   <UserInfoInput>
     <IconWrapper>
       <img src={icon} alt="" />
     </IconWrapper>
-    <Input type="text" placeholder={placeholder} />
+    <Input type="text" placeholder={placeholder} value={value} onChange={onChange} error={error} />
   </UserInfoInput>
 );
 

--- a/src/pages/EditProfile/UserInfoInputs.tsx
+++ b/src/pages/EditProfile/UserInfoInputs.tsx
@@ -1,20 +1,97 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import InfoInput from "./InfoInput";
 import email from "../../assets/email.svg";
 import mobile from "../../assets/mobile.svg";
 import blog from "../../assets/blog.svg";
 import gitHub from "../../assets/github.svg";
 import instagram from "../../assets/instagram.svg";
+import { validateInput } from "../../utils/validInput";
 
-const UserInfoInputs: React.FC = () => {
+interface UserInfoInputsProps {
+  onChange: (data: {
+    email: string;
+    mobile: string;
+    github: string;
+    instagram: string;
+    blog: string;
+  }) => void;
+}
+
+const UserInfoInputs: React.FC<UserInfoInputsProps> = ({ onChange }) => {
+  const [emailValue, setEmailValue] = useState("");
+  const [mobileValue, setMobileValue] = useState("");
+  const [githubValue, setGithubValue] = useState("");
+  const [instagramValue, setInstagramValue] = useState("");
+  const [blogValue, setBlogValue] = useState("");
+
+  const [errors, setErrors] = useState({
+    email: false,
+    mobile: false,
+    github: false,
+    instagram: false,
+    blog: false,
+  });
+
+  useEffect(() => {
+    const newErrors = {
+      email: validateInput("email", emailValue) ? false : true,
+      mobile: validateInput("mobile", mobileValue) ? false : true,
+      github: validateInput("github", githubValue) ? false : true,
+      instagram: validateInput("url", instagramValue) ? false : true,
+      blog: validateInput("url", blogValue) ? false : true,
+    };
+
+    setErrors(newErrors);
+
+    onChange({
+      email: emailValue,
+      mobile: mobileValue,
+      github: githubValue,
+      instagram: instagramValue,
+      blog: blogValue,
+    });
+  }, [emailValue, mobileValue, githubValue, instagramValue, blogValue, onChange]);
+
   return (
     <>
       <p>홍길동</p>
-      <InfoInput icon={email} placeholder="이메일을 입력해주세요." />
-      <InfoInput icon={mobile} placeholder="휴대폰 번호를 입력해주세요." />
-      <InfoInput icon={gitHub} placeholder="GitHub 링크를 입력해주세요." />
-      <InfoInput icon={instagram} placeholder="Instagram 링크를 입력해주세요." />
-      <InfoInput icon={blog} placeholder="Blog 링크를 입력해주세요." />
+      <InfoInput
+        icon={email}
+        placeholder="이메일을 입력해주세요."
+        value={emailValue}
+        onChange={e => setEmailValue(e.target.value)}
+        error={errors.email}
+      />
+
+      <InfoInput
+        icon={mobile}
+        placeholder="010-XXXX-XXXX의 형식을 지켜주세요"
+        value={mobileValue}
+        onChange={e => setMobileValue(e.target.value)}
+        error={errors.mobile}
+      />
+
+      <InfoInput
+        icon={gitHub}
+        placeholder="GitHub 링크를 입력해주세요."
+        value={githubValue}
+        onChange={e => setGithubValue(e.target.value)}
+        error={errors.github}
+      />
+
+      <InfoInput
+        icon={instagram}
+        placeholder="Instagram 링크를 입력해주세요."
+        value={instagramValue}
+        onChange={e => setInstagramValue(e.target.value)}
+      />
+
+      <InfoInput
+        icon={blog}
+        placeholder="Blog 링크를 입력해주세요."
+        value={blogValue}
+        onChange={e => setBlogValue(e.target.value)}
+      />
     </>
   );
 };

--- a/src/pages/Search/SearchPage.tsx
+++ b/src/pages/Search/SearchPage.tsx
@@ -12,7 +12,7 @@ import {
   PortfolioSection,
   Indicator,
 } from "./SearchPage.styles";
-import { jobs } from "../../data/dummyData";
+import { jobGroups } from "../../data/dummyData";
 import Tag from "../../components/Tag/Tag";
 import TechStack2 from "../../components/TechStack2/TechStack2";
 import { DummyData } from "../../data/profilePageData";
@@ -78,8 +78,8 @@ const SearchPage: React.FC = () => {
       <FilterSection>
         <Category>
           <Tag key={0} content={"전체"} onClick={() => handleTagClick("전체")} />
-          {jobs.slice(0, 3).map(job => (
-            <Tag key={job.jobCode} content={job.name} onClick={() => handleTagClick(job.name)} />
+          {jobGroups.slice(0, 3).map(job => (
+            <Tag key={job._id} content={job.job} onClick={() => handleTagClick(job.job)} />
           ))}
         </Category>
         <TechStackWrapper>

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -7,6 +7,7 @@ export const COLORS = {
   MAIN_GRAY: "#ABABAB",
   MAIN_BLACK: "#201E50",
   MAIN_BG: "#FFFFFF",
+  RED: "#FE5F55",
 };
 
 export const PADDINGS = {

--- a/src/types/api-types/UserType.ts
+++ b/src/types/api-types/UserType.ts
@@ -13,7 +13,7 @@ export interface UserProfileType {
   phoneNumber: string; // 전화번호
   links: string[]; // 관련 링크
   techStack: ITechStackType[]; // 기술 스택
-  jobGroup: number; // 직군 코드
+  jobGroup: string; // 직군
   profileImage: string; // 프로필 이미지 URL
 }
 

--- a/src/types/job.ts
+++ b/src/types/job.ts
@@ -1,4 +1,0 @@
-export interface Job {
-  jobCode: number;
-  name: string;
-}

--- a/src/utils/validInput.ts
+++ b/src/utils/validInput.ts
@@ -1,0 +1,12 @@
+export const validateInput = (type: "email" | "mobile" | "github" | "url", value: string) => {
+  const validators = {
+    email: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+    mobile: /^(010-\d{4}-\d{4})$/,
+    github: /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/?$/,
+    url: /^(https?:\/\/)?([\w.-]+)+(:\d+)?(\/[\w.-]*)*\/?$/,
+  };
+
+  const regex = validators[type];
+
+  return regex.test(value);
+};


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
> 검색 페이지
> 포트폴리오 등록 페이지
> 드롭다운 컴포넌트 2개
> 유저 api 타입
> 더미 데이터
- JobGroup 타입 업데이트
- 기존 Job 타입 삭제

> 프로필 등록 페이지 
- 사진 업로드 기능 추가
- 프로필 등록 기능 추가

## 📌 이슈 넘버
> #56 

## 📝 작업 내용
- Job 타입을 사용하는 컴포넌트들을 JobGroup타입을 사용하게 변경
- 직무 선택, 기술스태 선택 스타일 변경: 옆으로 길어지면 보이지 않기 때문
- 이메일, 번호, 링크들의 형식이 맞지않으면 빨갛게 표시
- 추후 로그인 페이지 개발이 완료되면 유저 정보를 가져와 미리 로드하는 기능 추가 예정

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/8c27f6d0-918e-475d-894e-8a4c1ba92773)
![image](https://github.com/user-attachments/assets/07d88634-9c32-421f-a8d8-ce2844fa1b38)



## 💬리뷰 요구사항(선택)