### PR TITLE
[FEAT] 헤더 반응형 등 기능 추가

### DIFF
--- a/src/components/Header/Header.styles.ts
+++ b/src/components/Header/Header.styles.ts
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 
 export const HeaderWrapper = styled.div`
   & {
+    position: relative;
     margin: 0;
     display: flex;
     justify-content: space-between;
@@ -10,46 +11,95 @@ export const HeaderWrapper = styled.div`
     box-shadow: 0 1px 0.5px -0.5px rgba(0, 0, 0, 0.25);
   }
 
-  .logo {
-    line-height: 3rem;
+  .wrap {
     display: flex;
+    align-items: center;
     gap: 5px;
-    cursor: pointer;
-  }
-  .logo img {
-    object-fit: contain;
   }
 
-  .wrap {
+  .btnWrap {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  }
+
+  @media (min-width: 900px) {
+    .md-hidden {
+      display: none;
+    }
+  }
+
+  @media (max-width: 900px) {
+    .md-flex {
+      display: none;
+    }
+    .searchIcon.md-hidden {
+      width: 1.5rem;
+      margin: 0 15px;
+      cursor: pointer;
+    }
+  }
+
+  .searchModal {
+    /* border: 3px solid black; */
+    background-color: ${({ theme }) => theme.COLORS.MAIN_BG};
+    width: 50vw;
+    height: 3.5rem;
+    position: absolute;
+    top: 3.5rem;
+    right: 0.5rem;
+
+    display: flex;
+    justify-content: end;
+    /* align-items: start; */
+    transition: 1s;
+  }
+  .searchModal.hidden {
+    height: 0;
+    overflow: hidden;
+    opacity: 0%;
+    transition: 1s;
+  }
+
+  .profileImg {
+    border-radius: ${({ theme }) => theme.BORDER_RADIUS.CIRCLE};
+    width: 2.3rem;
+    height: 2.3rem;
+    cursor: pointer;
+  }
+`;
+
+export const SearchBarWrapper = styled.div`
+  & {
     position: relative;
     display: flex;
     align-items: center;
     gap: 5px;
   }
-  .wrap .searchBar {
+  .searchBar {
     line-height: 1rem;
     width: 15rem;
     padding: 10px calc(${({ theme }) => theme.PADDINGS.X_SMALL});
     padding-left: 2.5rem;
     margin-right: 5px;
     border-radius: ${({ theme }) => theme.BORDER_RADIUS.HALF_CIRCLE};
-    border: 0.5px solid
-      rgb(from ${({ theme }) => theme.COLORS.MAIN_GRAY} r g b / 0.5);
-    background-color: rgb(
-      from ${({ theme }) => theme.COLORS.MAIN_GRAY} r g b / 0.15
-    );
+    border: 0.5px solid rgb(from ${({ theme }) => theme.COLORS.MAIN_GRAY} r g b / 0.5);
+    background-color: rgb(from ${({ theme }) => theme.COLORS.MAIN_GRAY} r g b / 0.15);
     color: ${({ theme }) => theme.COLORS.MAIN_BLACK};
   }
-  .wrap ::placeholder {
+  ::placeholder {
     color: rgb(from ${({ theme }) => theme.COLORS.MAIN_BLACK} r g b / 0.5);
   }
-  .wrap .searchBar:focus {
+  .searchBar:focus {
     outline: transparent;
   }
-
-  .wrap .searchIcon {
+  .searchIcon {
+    width: 1.5rem;
     position: absolute;
     left: 8px;
-    width: 1.5rem;
+    margin: 0;
+  }
+  .searchIcon.md-hidden {
+    margin: 0;
   }
 `;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,42 +1,195 @@
-import { HeaderWrapper } from "./Header.styles";
+import { HeaderWrapper, SearchBarWrapper } from "./Header.styles";
 import Button from "../Button/Button";
-import { Link } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import Logo from "../Logo/Logo";
+import { UserApiResType, UserProfileResType } from "../../types/api-types/UserType";
+import { useEffect, useState } from "react";
+import ky from "ky";
+import noImg from "../../assets/no_image.svg";
+const apiUrl = import.meta.env.VITE_SERVER_URL;
+import useStoreSearchPage from "../../store/store-search-page";
 
-interface HeaderProps {
-  onEnterSearch?: (word: string) => void;
-  onClickLogin?: () => void;
-  onClickRegister?: () => void;
+interface HeaderCompProps {
+  userProfile?: UserProfileResType;
+  isSearchPage: boolean;
+  isSearchOpen: boolean;
+  setIsSearchOpen: (b: boolean) => void;
+  toggleSearch: () => void;
 }
 
-const Header: React.FC<HeaderProps> = ({
-  onEnterSearch,
-  onClickLogin,
-  onClickRegister,
-}) => {
+const Header = () => {
+  const [isSearchPage, setIsSearchPage] = useState(false);
+  const [userId, setUserId] = useState<string | undefined>("");
+  const [userProfile, setUserProfile] = useState<UserProfileResType>();
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const location = useLocation();
+  const toggleSearch = () => {
+    setIsSearchOpen(!isSearchOpen);
+  };
+
+  useEffect(() => {
+    setIsSearchPage(location.pathname === "/search");
+  }, [useLocation()]);
+
+  useEffect(() => {
+    const fetchLoggedInUser = async () => {
+      try {
+        const response = await ky.get(`${apiUrl}/users/user`);
+        if (!response.ok) {
+          setUserId(undefined);
+          throw new Error("헤더: 유저 정보를 불러오는 데 실패했습니다.");
+        }
+
+        const jsonData: UserApiResType<UserProfileResType> = await response.json();
+        setUserProfile(jsonData.data);
+        setUserId(jsonData.data?.userID);
+        console.log("헤더: ", userId, "로 로그인되어있습니다.");
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchLoggedInUser();
+  }, []);
+
   return (
     <HeaderWrapper>
       <Link to="/" className="logo">
-        {/* <i className="logo"> */}
-        <img src="/tree-logo.svg" alt="tree-logo" />
-        <img src="/devporest-logo.svg" alt="DevPorest" />
-        {/* </i> */}
+        <Logo />
       </Link>
-      <div className="wrap">
-        <input
-          type="text"
-          className="searchBar"
-          placeholder="다양한 개발자 포트폴리오 검색"
-          onKeyDown={(ev) => {
-            if (ev.key === "Enter" && onEnterSearch) {
-              onEnterSearch("searchword");
-            }
-          }}
+      {userId ? (
+        <LoggedInHeaderComp
+          userProfile={userProfile}
+          isSearchPage={isSearchPage}
+          isSearchOpen={isSearchOpen}
+          setIsSearchOpen={setIsSearchOpen}
+          toggleSearch={toggleSearch}
         />
-        <img src="/search-icon.svg" className="searchIcon" alt="" />
-        <Button text="로그인" colorType={0} onClick={onClickLogin} />
-        <Button text="회원가입" colorType={3} onClick={onClickRegister} />
-      </div>
+      ) : (
+        <LoggedOutHeaderComp
+          isSearchPage={isSearchPage}
+          isSearchOpen={isSearchOpen}
+          setIsSearchOpen={setIsSearchOpen}
+          toggleSearch={toggleSearch}
+        />
+      )}
     </HeaderWrapper>
+  );
+};
+const LoggedInHeaderComp: React.FC<HeaderCompProps> = ({
+  userProfile,
+  isSearchPage,
+  isSearchOpen,
+  setIsSearchOpen,
+  toggleSearch,
+}) => {
+  return (
+    <>
+      <div className="wrap">
+        {isSearchPage ? (
+          ""
+        ) : (
+          <>
+            <div className="md-flex">
+              <SearchBar isMainBar={true} setIsSearchOpen={setIsSearchOpen} />
+            </div>
+            <img
+              className="searchIcon md-hidden"
+              src="/search-icon.svg"
+              alt=""
+              onClick={toggleSearch}
+            />
+          </>
+        )}
+        <Link to={`/profile/${userProfile?.userID}`}>
+          <img className="profileImg" src={userProfile?.profileImage || noImg} alt="image" />
+        </Link>
+      </div>
+      {isSearchPage ? (
+        ""
+      ) : (
+        <div className={`searchModal ${isSearchOpen ? "" : "hidden"}`}>
+          <SearchBar isMainBar={false} setIsSearchOpen={setIsSearchOpen} />
+        </div>
+      )}
+    </>
+  );
+};
+const LoggedOutHeaderComp: React.FC<HeaderCompProps> = ({
+  isSearchPage,
+  isSearchOpen,
+  setIsSearchOpen,
+  toggleSearch,
+}) => {
+  return (
+    <>
+      <div className="wrap">
+        {isSearchPage ? (
+          ""
+        ) : (
+          <div className="md-flex">
+            <SearchBar isMainBar={true} setIsSearchOpen={setIsSearchOpen} />
+          </div>
+        )}
+        <div className="btnWrap">
+          <Link to="/login">
+            <Button text="로그인" colorType={3} />
+          </Link>
+          {isSearchPage ? (
+            ""
+          ) : (
+            <img
+              className="searchIcon md-hidden"
+              src="/search-icon.svg"
+              alt=""
+              onClick={toggleSearch}
+            />
+          )}
+        </div>
+      </div>
+      {isSearchPage ? (
+        ""
+      ) : (
+        <div className={`searchModal ${isSearchOpen ? "" : "hidden"}`}>
+          <SearchBar isMainBar={false} setIsSearchOpen={setIsSearchOpen} />
+        </div>
+      )}
+    </>
+  );
+};
+
+const SearchBar = ({
+  isMainBar,
+  setIsSearchOpen,
+}: {
+  isMainBar: boolean;
+  setIsSearchOpen: (b: boolean) => void;
+}) => {
+  const [searchWord, setSearchWord] = useState("");
+  const { setSearchParams } = useStoreSearchPage();
+  const navigate = useNavigate();
+
+  const handleSearch = (ev: React.KeyboardEvent<HTMLInputElement>) => {
+    if (ev.key !== "Enter") return;
+    if (searchWord.trim()) {
+      setSearchParams({ keyword: searchWord });
+      navigate(`/search`);
+
+      console.log(`/search로 리디랙트(keyword:${searchWord})`);
+      setIsSearchOpen(false);
+    }
+  };
+  return (
+    <SearchBarWrapper>
+      <input
+        type="text"
+        className={`searchBar ${isMainBar ? "" : "md-hidden"}`}
+        placeholder="다양한 개발자 포트폴리오 검색"
+        value={searchWord}
+        onChange={ev => setSearchWord(ev.target.value)}
+        onKeyDown={handleSearch}
+      />
+      <img src="/search-icon.svg" className={`searchIcon ${isMainBar ? "" : "md-hidden"}`} alt="" />
+    </SearchBarWrapper>
   );
 };
 export default Header;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,42 +1,198 @@
-import { HeaderWrapper } from "./Header.styles";
+import { HeaderWrapper, SearchBarWrapper } from "./Header.styles";
 import Button from "../Button/Button";
-import { Link } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import Logo from "../Logo/Logo";
+import { UserApiResType, UserProfileResType } from "../../types/api-types/UserType";
+import { useEffect, useState } from "react";
+import ky from "ky";
+import noImg from "../../assets/no_image.svg";
+const apiUrl = import.meta.env.VITE_SERVER_URL;
+import useStoreSearchPage from "../../store/store-search-page";
 
-interface HeaderProps {
-  onEnterSearch?: (word: string) => void;
-  onClickLogin?: () => void;
-  onClickRegister?: () => void;
+interface HeaderCompProps {
+  userProfile?: UserProfileResType;
+  isSearchPage: boolean;
+  isSearchOpen: boolean;
+  setIsSearchOpen: (b: boolean) => void;
+  toggleSearch: () => void;
 }
 
-const Header: React.FC<HeaderProps> = ({
-  onEnterSearch,
-  onClickLogin,
-  onClickRegister,
-}) => {
+const Header = () => {
+  const [isSearchPage, setIsSearchPage] = useState(false);
+  const [userId, setUserId] = useState<string | undefined>("");
+  const [userProfile, setUserProfile] = useState<UserProfileResType>();
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const location = useLocation();
+  const toggleSearch = () => {
+    setIsSearchOpen(!isSearchOpen);
+  };
+
+  useEffect(() => {
+    setIsSearchPage(location.pathname === "/search");
+  }, [useLocation()]);
+
+  useEffect(() => {
+    const fetchLoggedInUser = async () => {
+      try {
+        const response = await ky.get(`${apiUrl}/users/user`);
+        if (!response.ok) {
+          setUserId(undefined);
+          throw new Error("헤더: 유저 정보를 불러오는 데 실패했습니다.");
+        }
+
+        const jsonData: UserApiResType<UserProfileResType> = await response.json();
+        setUserProfile(jsonData.data);
+        setUserId(jsonData.data?.userID);
+        console.log("헤더: ", userId, "로 로그인되어있습니다.");
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchLoggedInUser();
+  }, []);
+
   return (
     <HeaderWrapper>
       <Link to="/" className="logo">
-        {/* <i className="logo"> */}
-        <img src="/tree-logo.svg" alt="tree-logo" />
-        <img src="/devporest-logo.svg" alt="DevPorest" />
-        {/* </i> */}
+        <Logo />
       </Link>
-      <div className="wrap">
-        <input
-          type="text"
-          className="searchBar"
-          placeholder="다양한 개발자 포트폴리오 검색"
-          onKeyDown={(ev) => {
-            if (ev.key === "Enter" && onEnterSearch) {
-              onEnterSearch("searchword");
-            }
-          }}
+      {userId ? (
+        <LoggedInHeaderComp
+          userProfile={userProfile}
+          isSearchPage={isSearchPage}
+          isSearchOpen={isSearchOpen}
+          setIsSearchOpen={setIsSearchOpen}
+          toggleSearch={toggleSearch}
         />
-        <img src="/search-icon.svg" className="searchIcon" alt="" />
-        <Button text="로그인" colorType={0} onClick={onClickLogin} />
-        <Button text="회원가입" colorType={3} onClick={onClickRegister} />
-      </div>
+      ) : (
+        <LoggedOutHeaderComp
+          isSearchPage={isSearchPage}
+          isSearchOpen={isSearchOpen}
+          setIsSearchOpen={setIsSearchOpen}
+          toggleSearch={toggleSearch}
+        />
+      )}
     </HeaderWrapper>
+  );
+};
+const LoggedInHeaderComp: React.FC<HeaderCompProps> = ({
+  userProfile,
+  isSearchPage,
+  isSearchOpen,
+  setIsSearchOpen,
+  toggleSearch,
+}) => {
+  return (
+    <>
+      <div className="wrap">
+        {isSearchPage ? (
+          ""
+        ) : (
+          <>
+            <div className="md-flex">
+              <SearchBar isMainBar={true} setIsSearchOpen={setIsSearchOpen} />
+            </div>
+            <img
+              className="searchIcon md-hidden"
+              src="/search-icon.svg"
+              alt=""
+              onClick={toggleSearch}
+            />
+          </>
+        )}
+        <Link to={`/profile/${userProfile?.userID}`}>
+          <img className="profileImg" src={userProfile?.profileImage || noImg} alt="image" />
+        </Link>
+      </div>
+      {isSearchPage ? (
+        ""
+      ) : (
+        <div className={`searchModal ${isSearchOpen ? "" : "hidden"}`}>
+          <SearchBar isMainBar={false} setIsSearchOpen={setIsSearchOpen} />
+        </div>
+      )}
+    </>
+  );
+};
+const LoggedOutHeaderComp: React.FC<HeaderCompProps> = ({
+  isSearchPage,
+  isSearchOpen,
+  setIsSearchOpen,
+  toggleSearch,
+}) => {
+  return (
+    <>
+      <div className="wrap">
+        {isSearchPage ? (
+          ""
+        ) : (
+          <div className="md-flex">
+            <SearchBar isMainBar={true} setIsSearchOpen={setIsSearchOpen} />
+          </div>
+        )}
+        <div className="btnWrap">
+          <Link to="/login">
+            <Button text="로그인" colorType={0} />
+          </Link>
+          <Link to="/edit_profile">
+            <Button text="회원가입" colorType={3} />
+          </Link>
+          {isSearchPage ? (
+            ""
+          ) : (
+            <img
+              className="searchIcon md-hidden"
+              src="/search-icon.svg"
+              alt=""
+              onClick={toggleSearch}
+            />
+          )}
+        </div>
+      </div>
+      {isSearchPage ? (
+        ""
+      ) : (
+        <div className={`searchModal ${isSearchOpen ? "" : "hidden"}`}>
+          <SearchBar isMainBar={false} setIsSearchOpen={setIsSearchOpen} />
+        </div>
+      )}
+    </>
+  );
+};
+
+const SearchBar = ({
+  isMainBar,
+  setIsSearchOpen,
+}: {
+  isMainBar: boolean;
+  setIsSearchOpen: (b: boolean) => void;
+}) => {
+  const [searchWord, setSearchWord] = useState("");
+  const { setSearchParams } = useStoreSearchPage();
+  const navigate = useNavigate();
+
+  const handleSearch = (ev: React.KeyboardEvent<HTMLInputElement>) => {
+    if (ev.key !== "Enter") return;
+    if (searchWord.trim()) {
+      setSearchParams({ keyword: searchWord });
+      navigate(`/search`);
+
+      console.log(`/search로 리디랙트(keyword:${searchWord})`);
+      setIsSearchOpen(false);
+    }
+  };
+  return (
+    <SearchBarWrapper>
+      <input
+        type="text"
+        className={`searchBar ${isMainBar ? "" : "md-hidden"}`}
+        placeholder="다양한 개발자 포트폴리오 검색"
+        value={searchWord}
+        onChange={ev => setSearchWord(ev.target.value)}
+        onKeyDown={handleSearch}
+      />
+      <img src="/search-icon.svg" className={`searchIcon ${isMainBar ? "" : "md-hidden"}`} alt="" />
+    </SearchBarWrapper>
   );
 };
 export default Header;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
> 헤더 크기 반응형 (검색바 축소)
> 로그인 여부 확인 (api/users/user)
> 로그인, 회원가입 경로 이동
> search 페이지에서는 searchBar 숨기기

## 📌 이슈 넘버
- #55

## 📝 작업 내용
### 1. api/users/user에서 userId 불러오기
> 에러 시 로그인 안된 것으로 간주
> 로그인 되었다면 "로그인" 버튼 대신 프로필 사진 보여주기

### 2. 창의 가로길이 줄었을 경우 searchBar 드롭다운으로 변경
### 3. 로그인=>/login, 회원가입=>/edit_profile, 프로필=>/profile/userID, 검색=>/search 페이지 이동
### 4. /search 페이지에서는 searchBar 숨기기

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/5389c404-37ac-4cb5-adb2-19effc6829ee)
![image](https://github.com/user-attachments/assets/3c53a517-7e56-4558-a178-f9142b3ef101)
----
> 좁은창
![image](https://github.com/user-attachments/assets/0cea280f-3eac-4046-b69a-def11d456776)
----
> 좁은창(로그인)
![image](https://github.com/user-attachments/assets/25a85cb7-7c6c-4249-bc91-705c9f4b9c36)
----
> 검색페이지
![image](https://github.com/user-attachments/assets/6e099b4b-3dfb-46d5-9016-47b1f6122068)
![image](https://github.com/user-attachments/assets/3fea1e35-923a-4166-9f55-8a5b6e6e130c)

## 💬리뷰 요구사항(선택)

화면이 작아졌을 때 searchBar만 드롭다운으로 내려오는게 괜찮아보이는지 궁금합니다