### PR TITLE
[FEAT] 프로필 페이지 EmptyPortfolio렌더링 버그 수정

### DIFF
--- a/src/pages/Profile/ProfilePage.tsx
+++ b/src/pages/Profile/ProfilePage.tsx
@@ -68,6 +68,7 @@ const ProfilePage = () => {
   const [likePortfolioData, setLikePortfolioData] = useState<DetailPortfolioType[] | undefined>(undefined);
   const [pagination, setPagination] = useState<pagination | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(false);
+  const [portfolioList, setPortfolioList] = useState<DetailPortfolioType[] | undefined>(undefined);
 
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
@@ -90,6 +91,14 @@ const ProfilePage = () => {
     if ('data' in likePortfolio) setLikePortfolioData(prev => prev? [...prev, ...likePortfolio.data] : likePortfolio.data);
     if ('pagination' in likePortfolio) setPagination(likePortfolio.pagination);
   };
+
+  useEffect(() => {
+    setPortfolioList(userPortfolioData);
+  }, [userPortfolioData]);
+
+  useEffect(() => {
+    setPortfolioList(likePortfolioData);
+  }, [likePortfolioData]);
 
   useEffect(() => {
     fetchUserProfile();
@@ -145,8 +154,7 @@ const ProfilePage = () => {
   
 
   const handleCardClick = (portfolio_id: string) => {
-    console.log(`${portfolio_id}에 해당하는 페이지로 이동`);
-    navigate(`/detail?portfolio_id=${portfolio_id}`);
+    navigate(`/detail/${portfolio_id}`);
   };
 
   const onClickEditProfile = () => {
@@ -160,22 +168,9 @@ const ProfilePage = () => {
     return activeTab === "나의 포레스트" ? userPortfolioData : likePortfolioData;
   };
 
-  const renderPortfolioCards = (data: DetailPortfolioType[]) => {
-    return <UserPortfolioList>{data.map((item, index) => (
-      <PortfolioCard 
-        key={index} 
-        portfolio_id={item._id}
-        title={item.title}
-        thumbnailImg={item.thumbnailImage}
-        profileImg={profileData.profileImage}
-        userName={item.userInfo.name}
-        views={item.view}
-        likes={item.likeCount}
-        onClick={() => handleCardClick(item._id)} 
-      />
-    ))};
-    </UserPortfolioList>
-  };
+  // const renderPortfolioCards = (data: DetailPortfolioType[]) => {
+  //   return 
+  // };
 
   return (
     <ProfilePageWrapper>
@@ -249,16 +244,22 @@ const ProfilePage = () => {
           </UserInfoRight>
         </UserInfo>
         <TabComponent tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
-          {(() => {
-            const currentData = getCurrentData();
-            if (!currentData) return;
-            if (currentData.length === 0 && !isLoading) {
-              return <EmptyPortfolio text={activeTab === '나의 포레스트' ? '등록된 작업물이 없습니다.' : '좋아요를 누른 게시물이 없습니다.'} />;
-            }
-            return renderPortfolioCards(currentData);
-          })()}
+          <UserPortfolioList>{portfolioList && portfolioList.map((item, index) => (
+            <PortfolioCard 
+              key={index} 
+              portfolio_id={item._id}
+              title={item.title}
+              thumbnailImg={item.thumbnailImage}
+              profileImg={profileData.profileImage}
+              userName={item.userInfo.name}
+              views={item.view}
+              likes={item.likeCount}
+              onClick={() => handleCardClick(item._id)} 
+            />
+          ))}
+          </UserPortfolioList>
+        {portfolioList?.length === 0 && <EmptyPortfolio text={activeTab === '나의 포레스트' ? '등록된 작업물이 없습니다.' : '좋아요를 누른 게시물이 없습니다.'} />}
         {pagination?.hasNextPage && <Indicator ref={loadMoreRef} />}
-        {isLoading && <div>Loading...</div>}
       </ProfileContainer>
     </ProfilePageWrapper>
   );


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 프로필페이지

## 📌 이슈 넘버

> #79

## 📝 작업 내용
> 프로필 페이지의 탭('좋아요', '마이포레스트')을 바꿀 때 EmptyPortfolio가 잠시 렌더링되었다가 사라지는 현상 해결

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
