### PR TITLE
[FEAT] 포트폴리오 수정 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,10 @@ const App: React.FC = () => {
           <Route path="/search" element={<SearchPage />} />
           <Route path="/detail" element={<DetailPage />} />
           <Route path="/edit_portfolio" element={<EditPortfolioPage />} />
+          <Route
+            path="/edit_portfolio/:portfolioId"
+            element={<EditPortfolioPage />}
+          />
           <Route path="/profile/:userId" element={<ProfilePage />} />
           <Route path="/register" element={<Register />} />
         </Route>

--- a/src/api/get-portfolio-detail.ts
+++ b/src/api/get-portfolio-detail.ts
@@ -1,0 +1,13 @@
+import ky from "ky";
+import { PortfolioResType } from "../types/api-types/PortfolioType";
+
+const apiUrl = import.meta.env.VITE_SERVER_URL;
+
+export const getPortfolio = async (portfolioId: string): Promise<PortfolioResType> => {
+  try {
+    const response = await ky.get(`${apiUrl}/portfolios/${portfolioId}`);
+    return await response.json();
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/pages/EditPortfolio/EditPortfolioPage.styles.ts
+++ b/src/pages/EditPortfolio/EditPortfolioPage.styles.ts
@@ -2,9 +2,7 @@ import styled from "@emotion/styled";
 
 export const EditPortfolioPageWrapper = styled.section`
   & {
-    background-color: rgba(
-      from ${({ theme }) => theme.COLORS.MAIN_GRAY} r g b / 0.25
-    );
+    background-color: rgba(from ${({ theme }) => theme.COLORS.MAIN_GRAY} r g b / 0.25);
   }
   .mw-900 {
     max-width: 900px;
@@ -74,10 +72,10 @@ export const EditPortfolioPageWrapper = styled.section`
     justify-content: end;
     padding-bottom: 1rem;
   }
-  /*
+
   .links-section input {
     width: calc(100% - 34px);
-  } */
+  }
 
   .links-list {
     display: flex;
@@ -119,5 +117,21 @@ export const EditPortfolioPageWrapper = styled.section`
     display: contents;
     flex-wrap: wrap;
     gap: 8px;
+  }
+
+  .linkAddBtn {
+    background-color: ${({ theme }) => theme.COLORS.MAIN_BG};
+    border: solid 1px ${({ theme }) => theme.COLORS.MAIN_BLACK};
+    color: ${({ theme }) => theme.COLORS.MAIN_BLACK};
+    font-weight: ${({ theme }) => theme.FONT_WEIGHT.THICK};
+    border-radius: ${({ theme }) => theme.BORDER_RADIUS.HALF_CIRCLE};
+    /* padding: ${({ theme }) => theme.PADDINGS.X_SMALL} ${({ theme }) => theme.PADDINGS.SMALL}; */
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+
+    &:hover {
+      border: solid 1px #525b76;
+      color: #525b76;
+    }
   }
 `;

--- a/src/pages/EditPortfolio/EditPortfolioPage.tsx
+++ b/src/pages/EditPortfolio/EditPortfolioPage.tsx
@@ -206,14 +206,11 @@ const EditPortfolioPage = () => {
             <img src="/link-icon.svg" alt="link" />
             <input
               type="url"
-              placeholder="https://example.com"
+              placeholder="https://example.com (enter로 추가)"
               value={newLink}
               onChange={e => setNewLink(e.target.value)}
               onKeyDown={handleLinkKeyDown}
             />
-            <button type="button" onClick={handleAddLink}>
-              추가
-            </button>
 
             {formData.links && formData.links.length > 0 && (
               <div className="links-list">

--- a/src/pages/EditPortfolio/MyCKEditor/MyCKEditor.css
+++ b/src/pages/EditPortfolio/MyCKEditor/MyCKEditor.css
@@ -22,7 +22,7 @@
 
 .editor-container_classic-editor .editor-container__editor {
   max-width: 900px;
-  min-width: 795px;
+  /* min-width: 795px; */
 }
 
 .ck-editor__editable {

--- a/src/pages/EditPortfolio/MyCKEditor/MyCKEditor.tsx
+++ b/src/pages/EditPortfolio/MyCKEditor/MyCKEditor.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { CKEditor } from "@ckeditor/ckeditor5-react";
+import { Editor as CKEditorType } from "@ckeditor/ckeditor5-core";
 
 import "./MyCKEditor.css";
 import "ckeditor5/ckeditor5.css";
@@ -44,18 +45,27 @@ import translations from "ckeditor5/translations/ko.js";
 
 interface MyCKEditorProps {
   onChange?: (content: string) => void;
+  initialContent?: string;
 }
 
-const MyCKEditor = ({ onChange }: MyCKEditorProps) => {
+const MyCKEditor = ({ onChange, initialContent }: MyCKEditorProps) => {
   const editorContainerRef = useRef(null);
   const editorRef = useRef(null);
   const [isLayoutReady, setIsLayoutReady] = useState(false);
+  const [editorInstance, setEditorInstance] = useState<CKEditorType | null>(null);
 
   useEffect(() => {
     setIsLayoutReady(true);
 
     return () => setIsLayoutReady(false);
   }, []);
+
+  // initialContent가 변경될 때 에디터 내용 업데이트
+  useEffect(() => {
+    if (editorInstance && initialContent !== undefined) {
+      editorInstance.setData(initialContent);
+    }
+  }, [initialContent, editorInstance]);
 
   const editorConfig = {
     toolbar: {
@@ -175,7 +185,8 @@ const MyCKEditor = ({ onChange }: MyCKEditorProps) => {
       ],
     },
     initialData:
-      "<h2>포트폴리오 생성 공간에 오신 것을 환영합니다🎉</h2>\n<p>나만의 포트폴리오를 만들어보세요</p>  ",
+      initialContent ||
+      "<h2>포트폴리오 생성 공간에 오신 것을 환영합니다🎉</h2>\n<p>나만의 포트폴리오를 만들어보세요</p>",
     link: {
       addTargetToExternalLinks: true,
       defaultProtocol: "https://",
@@ -212,10 +223,7 @@ const MyCKEditor = ({ onChange }: MyCKEditorProps) => {
   return (
     <div>
       <div className="main-container">
-        <div
-          className="editor-container editor-container_classic-editor"
-          ref={editorContainerRef}
-        >
+        <div className="editor-container editor-container_classic-editor" ref={editorContainerRef}>
           <div className="editor-container__editor">
             <div ref={editorRef}>
               {isLayoutReady && (
@@ -228,6 +236,12 @@ const MyCKEditor = ({ onChange }: MyCKEditorProps) => {
                       onChange(data);
                     }
                     // console.log(data);
+                  }}
+                  onReady={editor => {
+                    setEditorInstance(editor);
+                    if (initialContent) {
+                      editor.setData(initialContent);
+                    }
                   }}
                 />
               )}

--- a/src/types/api-types/PortfolioType.ts
+++ b/src/types/api-types/PortfolioType.ts
@@ -29,8 +29,7 @@ export interface DetailPortfolioType extends PortfolioType {
  * --------------------------------------------------
  */
 // ReqBody
-export interface PostPortfolioType
-  extends Omit<PortfolioType, "techStack" | "jobGroup"> {
+export interface PostPortfolioType extends Omit<PortfolioType, "techStack" | "jobGroup"> {
   techStack: string[]; // ITechStackType[]에서 skill만 추출한 string 배열
   jobGroup: string; // optional에서 required로 변경
 }
@@ -40,6 +39,13 @@ export interface PortfolioResType {
   success: boolean; // 성공 여부
   message: string;
   data?: DetailPortfolioType;
+}
+
+// ResBody
+export interface PortfolioDetailResType {
+  success: boolean;
+  message: string;
+  _id: string;
 }
 
 /**


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
포트폴리오 수정 페이지 구현

## 📌 이슈 넘버
- #63 

## 📝 작업 내용
- 포트폴리오 id가 params에 있을 시, 포트폴리오 디테일 조회를 통하여 데이터 가져온 상태로 보이도록 함
- 포트폴리오 디테일 조회 res type 새로 생성
- src/api/create-portfolio.ts 수정 로직 추가
   - prettier 적용으로 인해 기존 여러줄에 걸친 코드 -> 한 줄 코드로 수정되어서, 이 파일에서는 마지막 부분(포트폴리오 생성/수정 통합 함수) 부분만 봐주시면 됩니다.
   - 현재 수정 시 기존 url 삭제 기능이 없어, 추후 추가할 예정입니다.

## 📸 스크린샷(선택)
포트폴리오 수정페이지로 들어가면, 기존 내용이 잘 반영된 상태로 수정을 진행할 수 있습니다.
![image](https://github.com/user-attachments/assets/200a0aae-1c7b-4076-8236-a8fb003bad2e)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
