### PR TITLE
[FEAT] 포폴 생성 및 수정 로직 변경

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/tree-logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>DEVPOREST</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/api/create-portfolio.ts
+++ b/src/api/create-portfolio.ts
@@ -1,11 +1,11 @@
 import api from "./index";
-import { uploadSingleImg } from "./upload-single-img";
+import { uploadTumbnailImg } from "./upload-single-img";
 import {
   PortfolioType,
   PortfolioResType,
   PortfolioImagesResType,
   PostPortfolioType,
-  PortfolioDetailResType,
+  PortfolioEditResType,
 } from "../types/api-types/PortfolioType";
 
 /**
@@ -50,7 +50,7 @@ const extractImagesFromContent = (
 /**
  * 다중 이미지 업로드 처리
  */
-const uploadMultipleImages = async (files: File[]): Promise<string[]> => {
+const uploadMultipleImages = async (files: File[], portfolioId: string): Promise<string[]> => {
   const formData = new FormData();
   files.forEach(file => {
     formData.append("images", file);
@@ -58,7 +58,7 @@ const uploadMultipleImages = async (files: File[]): Promise<string[]> => {
 
   try {
     const response = await api
-      .post("portfolios/uploads", {
+      .post(`portfolios/uploads/${portfolioId}?usage=content`, {
         body: formData,
       })
       .json<PortfolioImagesResType>();
@@ -79,6 +79,7 @@ const uploadMultipleImages = async (files: File[]): Promise<string[]> => {
  */
 const processEditorContent = async (
   content: string,
+  portfolioId: string,
 ): Promise<{
   updatedContent: string;
   uploadedUrls: string[];
@@ -98,7 +99,7 @@ const processEditorContent = async (
   );
 
   // 다중 이미지 업로드
-  const uploadedUrls = await uploadMultipleImages(imageFiles);
+  const uploadedUrls = await uploadMultipleImages(imageFiles, portfolioId);
 
   // 컨텐츠 내 이미지 URL 교체
   let updatedContent = content;
@@ -117,68 +118,88 @@ const processEditorContent = async (
  */
 const transformToServerFormat = (
   clientData: PortfolioType,
-  uploadedImages: string[],
+  uploadedImages?: string[],
 ): PostPortfolioType => {
   return {
     ...clientData,
     techStack: clientData.techStack?.map(tech => tech.skill) || [],
     jobGroup: clientData.jobGroup || "",
-    images: uploadedImages,
+    images: uploadedImages || [],
   };
 };
 
 // 포트폴리오 데이터 처리 및 변환 공통 함수
-const processPortfolioData = async (portfolioData: PortfolioType): Promise<PostPortfolioType> => {
-  // 1. 썸네일 이미지 처리
-  let thumbnailUrl = portfolioData.thumbnailImage;
-  if (thumbnailUrl?.startsWith("data:image")) {
-    const thumbnailFile = await base64ToFile(thumbnailUrl, "thumbnail.png");
-    const uploadedThumbnailUrl = await uploadSingleImg(thumbnailFile);
-    if (!uploadedThumbnailUrl) {
-      throw new Error("썸네일 이미지 업로드 실패");
-    }
-    thumbnailUrl = uploadedThumbnailUrl;
+const processPortfolioData = async (
+  portfolioData: PortfolioType,
+  portfolioId?: string,
+): Promise<PortfolioEditResType> => {
+  // 0. 생성 api 호출
+  console.log("포트폴리오 데이터:", portfolioData);
+  let _id = portfolioId;
+  console.log("포트폴리오 아이디:", _id);
+  if (!_id) {
+    const response = await api
+      .post("portfolios", {
+        json: transformToServerFormat({ ...portfolioData, thumbnailImage: " ", contents: " " }), // base64 제외 하고 보냄
+      })
+      .json<PortfolioResType>();
+    _id = response.data?._id;
   }
 
-  // 2. 에디터 컨텐츠 내 이미지 처리
-  const { updatedContent, uploadedUrls } = await processEditorContent(portfolioData.contents);
+  // _id가 있는 상태
 
-  // 3. 서버 형식으로 데이터 변환
-  return transformToServerFormat(
-    {
-      ...portfolioData,
-      thumbnailImage: thumbnailUrl,
-      contents: updatedContent,
-    },
-    uploadedUrls,
-  );
+  if (_id) {
+    console.log("있어야 하는 포트폴리오 아이디:", _id);
+    console.log("포트폴리오 데이터:", portfolioData);
+    // 1. 썸네일 이미지 처리
+    let thumbnailUrl = portfolioData.thumbnailImage; // base64 이미지
+    if (thumbnailUrl?.startsWith("data:image")) {
+      const thumbnailFile = await base64ToFile(thumbnailUrl, "thumbnail.png");
+      const uploadedThumbnailUrl = await uploadTumbnailImg(thumbnailFile, _id);
+      if (!uploadedThumbnailUrl) {
+        throw new Error("썸네일 이미지 업로드 실패");
+      }
+      thumbnailUrl = uploadedThumbnailUrl;
+    }
+
+    // 2. 에디터 컨텐츠 내 이미지 처리
+    const { updatedContent, uploadedUrls } = await processEditorContent(
+      portfolioData.contents,
+      _id,
+    );
+
+    // 3. 서버 형식으로 데이터 변환
+    const serverData = transformToServerFormat(
+      {
+        ...portfolioData,
+        thumbnailImage: thumbnailUrl,
+        contents: updatedContent,
+      },
+      uploadedUrls,
+    );
+    console.log("서버형식으로 변환된 데이터:", serverData);
+    // 수정 api 이용하여 변환된 이미지 src 집어넣기
+    const response = await api
+      .put(`portfolios/${_id}`, {
+        json: serverData,
+      })
+      .json<PortfolioEditResType>();
+    return response;
+  }
+  return {} as PortfolioEditResType;
 };
 
 // 포트폴리오 생성/수정 통합 함수
 export const handlePortfolio = async (
   portfolioData: PortfolioType,
   portfolioId?: string,
-): Promise<PortfolioResType | PortfolioDetailResType> => {
+): Promise<PortfolioEditResType> => {
   try {
-    const processedData = await processPortfolioData(portfolioData);
+    const processedData = await processPortfolioData(portfolioData, portfolioId);
 
-    if (portfolioId) {
-      // 수정
-      const response = await api
-        .put(`portfolios/${portfolioId}`, {
-          json: processedData,
-        })
-        .json<PortfolioDetailResType>();
-      return response;
-    } else {
-      // 생성
-      const response = await api
-        .post("portfolios", {
-          json: processedData,
-        })
-        .json<PortfolioResType>();
-      return response;
-    }
+    console.log("포트폴리오 처리 데이터:", processedData);
+
+    return { success: true, message: "포트폴리오 처리 성공", _id: processedData._id };
   } catch (error) {
     console.error("포트폴리오 처리 오류:", error);
     throw error;

--- a/src/api/delete-portfolio.ts
+++ b/src/api/delete-portfolio.ts
@@ -1,0 +1,15 @@
+import api from "./index";
+import { PortfolioDeleteResType } from "../types/api-types/PortfolioType";
+
+export const deletePortfolio = async (portfolioId: string): Promise<PortfolioDeleteResType> => {
+  try {
+    const response = await api.delete(`portfolios/${portfolioId}`).json<PortfolioDeleteResType>();
+    return response;
+  } catch (error) {
+    console.error("포트폴리오 삭제 실패:", error);
+    return {
+      success: false,
+      message: "포트폴리오 삭제에 실패했습니다.",
+    };
+  }
+};

--- a/src/api/upload-multiple-imgs.ts
+++ b/src/api/upload-multiple-imgs.ts
@@ -1,17 +1,19 @@
 import api from "./index";
 import { PortfolioThumbnailResType } from "../types/api-types/PortfolioType";
 
+// 현재 사용하지 않는 함수, create-portfolio.ts에서 자체적으로 이미지 업로드를 처리함
 export const uploadMultipleImages = async (
-  images: File[]
+  images: File[],
+  portfolioId?: string,
 ): Promise<string[]> => {
   const formData = new FormData();
-  images.forEach((image) => {
+  images.forEach(image => {
     formData.append("images", image);
   });
 
   try {
     const response = await api
-      .post("portfolios/uploads", {
+      .post(`portfolios/uploads/${portfolioId}?usage=content`, {
         body: formData,
       })
       .json<PortfolioThumbnailResType>();

--- a/src/api/upload-single-img.ts
+++ b/src/api/upload-single-img.ts
@@ -1,12 +1,15 @@
 import api from "./index";
 import { PortfolioThumbnailResType } from "../types/api-types/PortfolioType";
 
-export const uploadSingleImg = async (img: File): Promise<string | undefined> => {
+export const uploadTumbnailImg = async (
+  img: File,
+  portfolioId: string,
+): Promise<string | undefined> => {
   const formData = new FormData();
   formData.append("image", img);
   try {
     const response = await api
-      .post("portfolios/upload", {
+      .post(`portfolios/upload/${portfolioId}?usage=thumbnail`, {
         body: formData,
       })
       .json<PortfolioThumbnailResType>();

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -138,21 +138,11 @@ const LoggedInHeaderComp: React.FC<HeaderCompProps> = ({
     }
 
     try {
-      // userID에 대한 프로필 존재 여부를 확인하는 API 요청
-      const response = await userApi.get(`profile/${userProfile.userID}`);
-      console.log("ressss:", response);
-
-      if (response.ok) {
-        // 프로필이 존재하는 경우에만 페이지 이동
-        navigate(`/profile/${userProfile.userID}`);
-      }
-    } catch (error: any) {
-      if (error.response?.status === 404) {
-        alert("해당 프로필이 존재하지 않습니다.");
-      } else {
-        console.error("프로필로 이동중 오류 발생:", error);
-        alert("프로필페이지로 이동하는 도중 문제가 발생했습니다.");
-      }
+      if (!userProfile.newUser) navigate(`/profile/${userProfile.userID}`);
+      else alert("해당 프로필이 존재하지 않습니다.");
+    } catch (error) {
+      console.error("프로필로 이동중 오류 발생:", error);
+      alert("프로필페이지로 이동하는 도중 문제가 발생했습니다.");
     }
   };
 

--- a/src/pages/EditPortfolio/EditPortfolioPage.tsx
+++ b/src/pages/EditPortfolio/EditPortfolioPage.tsx
@@ -19,7 +19,6 @@ const EditPortfolioPage = () => {
   const navigate = useNavigate();
   const { techStackList, jobGroupList } = useTechStacksAndJobGroups();
   const { portfolioId } = useParams<{ portfolioId: string }>();
-
   const [formData, setFormData] = useState<Omit<PortfolioType, "userInfo">>({
     title: "",
     contents: "",
@@ -60,6 +59,7 @@ const EditPortfolioPage = () => {
         const selectedJobGroup = jobGroupList.find(job => job.job === portfolioData?.jobGroup);
         if (selectedJobGroup) {
           setDisplayJobGroup(selectedJobGroup.job);
+          handleInputChange("jobGroup", selectedJobGroup._id); // 수정 api 요청시에는 _id를 사용
         }
       } catch (error) {
         alert("포트폴리오 데이터를 불러오는데 실패했습니다.");
@@ -153,20 +153,14 @@ const EditPortfolioPage = () => {
     }
 
     try {
+      console.log("formData:", formData);
+      // console.log("formData title ", formData.title);
       const response = await handlePortfolio(formData as PortfolioType, portfolioId);
-      alert(
-        portfolioId
-          ? "포트폴리오가 성공적으로 수정되었습니다."
-          : "포트폴리오가 성공적으로 등록되었습니다.",
-      );
-      // PortfolioResType은 생성 응답, PortfolioDetailResType은 수정 응답
-      if ("data" in response) {
-        // 생성 응답
-        navigate(`/detail/${response.data?._id}`);
-      } else {
-        // 수정 응답
-        navigate(`/detail/${portfolioId}`);
-      }
+
+      // 생성도 수정을 거치면서, 생성 수정 response가 동일해져서 분간 힘듦
+      // 작성완료버튼 누르면 -> alert 대신 그냥 바로 디테일 페이지로 넘어가는걸로...
+
+      navigate(`/detail/${response._id}`);
     } catch (error) {
       alert(
         portfolioId

--- a/src/pages/EditPortfolio/MyCKEditor/MyCKEditor.tsx
+++ b/src/pages/EditPortfolio/MyCKEditor/MyCKEditor.tsx
@@ -53,6 +53,7 @@ const MyCKEditor = ({ onChange, initialContent }: MyCKEditorProps) => {
   const editorRef = useRef(null);
   const [isLayoutReady, setIsLayoutReady] = useState(false);
   const [editorInstance, setEditorInstance] = useState<CKEditorType | null>(null);
+  const [isInitialized, setIsInitialized] = useState(false);
 
   useEffect(() => {
     setIsLayoutReady(true);
@@ -62,10 +63,14 @@ const MyCKEditor = ({ onChange, initialContent }: MyCKEditorProps) => {
 
   // initialContent가 변경될 때 에디터 내용 업데이트
   useEffect(() => {
-    if (editorInstance && initialContent !== undefined) {
-      editorInstance.setData(initialContent);
+    if (editorInstance && initialContent !== undefined && !isInitialized) {
+      editorInstance.setData(
+        initialContent ||
+          "<h2>포트폴리오 생성 공간에 오신 것을 환영합니다🎉</h2>\n<p>나만의 포트폴리오를 만들어보세요</p>",
+      );
+      setIsInitialized(true);
     }
-  }, [initialContent, editorInstance]);
+  }, [initialContent, editorInstance, isInitialized]);
 
   const editorConfig = {
     toolbar: {
@@ -185,7 +190,6 @@ const MyCKEditor = ({ onChange, initialContent }: MyCKEditorProps) => {
       ],
     },
     initialData:
-      initialContent ||
       "<h2>포트폴리오 생성 공간에 오신 것을 환영합니다🎉</h2>\n<p>나만의 포트폴리오를 만들어보세요</p>",
     link: {
       addTargetToExternalLinks: true,
@@ -239,8 +243,9 @@ const MyCKEditor = ({ onChange, initialContent }: MyCKEditorProps) => {
                   }}
                   onReady={editor => {
                     setEditorInstance(editor);
-                    if (initialContent) {
+                    if (initialContent && !isInitialized) {
                       editor.setData(initialContent);
+                      setIsInitialized(true);
                     }
                   }}
                 />

--- a/src/pages/EditPortfolio/MyCKEditor/MyCKEditor.tsx
+++ b/src/pages/EditPortfolio/MyCKEditor/MyCKEditor.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { CKEditor } from "@ckeditor/ckeditor5-react";
-import { Editor as CKEditorType } from "@ckeditor/ckeditor5-core";
+// import { Editor as CKEditorType } from "@ckeditor/ckeditor5-core";
 
 import "./MyCKEditor.css";
 import "ckeditor5/ckeditor5.css";

--- a/src/pages/EditPortfolio/MyCKEditor/MyCKEditor.tsx
+++ b/src/pages/EditPortfolio/MyCKEditor/MyCKEditor.tsx
@@ -52,8 +52,7 @@ const MyCKEditor = ({ onChange, initialContent }: MyCKEditorProps) => {
   const editorContainerRef = useRef(null);
   const editorRef = useRef(null);
   const [isLayoutReady, setIsLayoutReady] = useState(false);
-  const [editorInstance, setEditorInstance] = useState<CKEditorType | null>(null);
-  const [isInitialized, setIsInitialized] = useState(false);
+  // const [editorInstance, setEditorInstance] = useState<CKEditorType | null>(null);
 
   useEffect(() => {
     setIsLayoutReady(true);
@@ -62,15 +61,11 @@ const MyCKEditor = ({ onChange, initialContent }: MyCKEditorProps) => {
   }, []);
 
   // initialContent가 변경될 때 에디터 내용 업데이트
-  useEffect(() => {
-    if (editorInstance && initialContent !== undefined && !isInitialized) {
-      editorInstance.setData(
-        initialContent ||
-          "<h2>포트폴리오 생성 공간에 오신 것을 환영합니다🎉</h2>\n<p>나만의 포트폴리오를 만들어보세요</p>",
-      );
-      setIsInitialized(true);
-    }
-  }, [initialContent, editorInstance, isInitialized]);
+  // useEffect(() => {
+  //   if (editorInstance && initialContent !== undefined) {
+  //     editorInstance.setData(initialContent);
+  //   }
+  // }, [initialContent, editorInstance]);
 
   const editorConfig = {
     toolbar: {
@@ -190,6 +185,7 @@ const MyCKEditor = ({ onChange, initialContent }: MyCKEditorProps) => {
       ],
     },
     initialData:
+      initialContent ||
       "<h2>포트폴리오 생성 공간에 오신 것을 환영합니다🎉</h2>\n<p>나만의 포트폴리오를 만들어보세요</p>",
     link: {
       addTargetToExternalLinks: true,
@@ -241,13 +237,12 @@ const MyCKEditor = ({ onChange, initialContent }: MyCKEditorProps) => {
                     }
                     // console.log(data);
                   }}
-                  onReady={editor => {
-                    setEditorInstance(editor);
-                    if (initialContent && !isInitialized) {
-                      editor.setData(initialContent);
-                      setIsInitialized(true);
-                    }
-                  }}
+                  // onReady={editor => {
+                  //   setEditorInstance(editor);
+                  //   if (initialContent) {
+                  //     editor.setData(initialContent);
+                  //   }
+                  // }}
                 />
               )}
             </div>

--- a/src/pages/EditProfile/EditProfilePage.tsx
+++ b/src/pages/EditProfile/EditProfilePage.tsx
@@ -34,7 +34,7 @@ import { GithubUserProfileResType, UserProfileResType } from "../../types/api-ty
 import { JobGroupType } from "../../types/api-types/JobGroup";
 
 //api
-import { uploadSingleImg } from "../../api/upload-single-img";
+// import { uploadSingleImg } from "../../api/upload-single-img";
 import { createProfile, modifyProfile } from "../../api/create-profile";
 import { getJobGroup } from "../../api/get-job-group";
 import { getTechStacks } from "../../api/get-tech-stacks";
@@ -209,7 +209,7 @@ const EditProfilePage: React.FC = () => {
     }
 
     if (profileImage) {
-      profileImgUrl = (await uploadSingleImg(profileImage)) ?? "";
+      // profileImgUrl = (await uploadSingleImg(profileImage)) ?? "";
 
       setUserInfo(prev => {
         return { ...prev, profileImage: profileImgUrl };

--- a/src/types/api-types/PortfolioType.ts
+++ b/src/types/api-types/PortfolioType.ts
@@ -7,7 +7,7 @@ export interface PortfolioType {
   images?: string[]; // 이미지들
   tags?: string[]; // 태그들
   techStack: ITechStackType[]; // 기술스택
-  thumbnailImage: string; // 썸네일 이미지
+  thumbnailImage?: string; // 썸네일 이미지
   userInfo: Pick<UserProfileResType, "userID" | "name" | "profileImage">;
   jobGroup: string; // 직군
   links?: string[];
@@ -42,7 +42,7 @@ export interface PortfolioResType {
 }
 
 // ResBody
-export interface PortfolioDetailResType {
+export interface PortfolioEditResType {
   success: boolean;
   message: string;
   _id: string;

--- a/src/types/api-types/PortfolioType.ts
+++ b/src/types/api-types/PortfolioType.ts
@@ -48,6 +48,11 @@ export interface PortfolioEditResType {
   _id: string;
 }
 
+export interface PortfolioDeleteResType {
+  success: boolean;
+  message: string;
+}
+
 /**
  * --------------------------------------------------
  * API 응답

--- a/src/types/api-types/PortfolioType.ts
+++ b/src/types/api-types/PortfolioType.ts
@@ -7,7 +7,7 @@ export interface PortfolioType {
   images?: string[]; // 이미지들
   tags?: string[]; // 태그들
   techStack: ITechStackType[]; // 기술스택
-  thumbnailImage?: string; // 썸네일 이미지
+  thumbnailImage: string; // 썸네일 이미지
   userInfo: Pick<UserProfileResType, "userID" | "name" | "profileImage">;
   jobGroup: string; // 직군
   links?: string[];


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
포폴 생성 및 수정 로직 변경

## 📌 이슈 넘버

- #87 

## 📝 작업 내용
완료된 작업

- 포폴 생성 및 수정 로직 변경 
- 변경된 이미지 업로드 api를 사용하기 위해, 포트폴리오의 _id가 필요했었습니다.
   그래서 다음의 로직을 활용했습니다!

  1. 포트폴리오 생성 -> 썸네일은 "" , images = [] 로 해서 일단 빈 값을 넘긴뒤에, 생성되는 포트폴리오의 id를 받아옵니다.
  2. 받은 id 가지고 이미지 업로드 api 를 썸네일 업로드 , 본문 이미지 업로드 이렇게 2번 실행해줍니다.
  3. 만약에 2번의 실행중에 하나라도 에러가 나면 해당 id의 포트폴리오를 삭제해줍니다.
  4. 이미지 업로드 성공하면 , 수정 api로 변환된 이미지 url로 대입하기

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
