### PR TITLE
🐛 수정 시 에디터 내용 불러오기&작성 버그 수정

### DIFF
--- a/src/pages/Detail/DetailPage.styles.ts
+++ b/src/pages/Detail/DetailPage.styles.ts
@@ -116,6 +116,10 @@ export const ContentSection = styled.section`
     border-radius: ${({ theme }) => theme.BORDER_RADIUS.DEFAULT};
     object-fit: contain;
   }
+
+  .ck-content {
+    max-height: fit-content;
+  }
 `;
 
 export const ActionBtnSection = styled.section`

--- a/src/pages/Detail/DetailPage.tsx
+++ b/src/pages/Detail/DetailPage.tsx
@@ -17,6 +17,7 @@ import {
   CommentView,
   Indicator,
 } from "./DetailPage.styles";
+import "ckeditor5/ckeditor5.css";
 import noImg from "../../assets/no_image.svg";
 import TechStack from "../../components/TechStack/TechStack";
 import Tag from "../../components/Tag/Tag";
@@ -276,7 +277,9 @@ const DetailPage: React.FC = () => {
       <ContentSection>
         <img src={portfolioData?.thumbnailImage || noImg} />
         <p style={{ height: "5rem" }} />
-        {portfolioData?.contents ? HTMLReactParser(portfolioData.contents) : ""}
+        <div className="ck-content">
+          {portfolioData?.contents ? HTMLReactParser(portfolioData.contents) : ""}
+        </div>
       </ContentSection>
       <ActionBtnSection>
         {alertText && <Alert text={alertText} />}

--- a/src/pages/EditPortfolio/EditPortfolioPage.tsx
+++ b/src/pages/EditPortfolio/EditPortfolioPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { Editor as CKEditorType } from "@ckeditor/ckeditor5-core";
 import { EditPortfolioPageWrapper } from "./EditPortfolioPage.styles";
 import Tag from "../../components/Tag/Tag";
 import Button from "../../components/Button/Button";
@@ -32,6 +33,7 @@ const EditPortfolioPage = () => {
   // 화면에 표시할 jobGroup.job을 위한 별도의 상태 -> post 요청 시에는 jobGroup._id를 사용
   const [displayJobGroup, setDisplayJobGroup] = useState<string>("");
   const [newLink, setNewLink] = useState<string>("");
+  const [editorInstance, setEditorInstance] = useState<CKEditorType | null>(null);
 
   // 포트폴리오 데이터 불러오기
   useEffect(() => {
@@ -41,7 +43,7 @@ const EditPortfolioPage = () => {
       try {
         const response = await getPortfolio(portfolioId);
         const portfolioData = response.data;
-        //console.log("portfolioData:", portfolioData);
+
         if (portfolioData) {
           setFormData({
             title: portfolioData.title,
@@ -53,13 +55,18 @@ const EditPortfolioPage = () => {
             jobGroup: portfolioData.jobGroup,
             links: portfolioData.links || [],
           });
-        }
 
-        // jobGroup 표시 이름 설정
-        const selectedJobGroup = jobGroupList.find(job => job.job === portfolioData?.jobGroup);
-        if (selectedJobGroup) {
-          setDisplayJobGroup(selectedJobGroup.job);
-          handleInputChange("jobGroup", selectedJobGroup._id); // 수정 api 요청시에는 _id를 사용
+          // 에디터 내용 업데이트
+          if (editorInstance) {
+            editorInstance.setData(portfolioData.contents);
+          }
+
+          // jobGroup 표시 이름 설정
+          const selectedJobGroup = jobGroupList.find(job => job.job === portfolioData?.jobGroup);
+          if (selectedJobGroup) {
+            setDisplayJobGroup(selectedJobGroup.job);
+            handleInputChange("jobGroup", selectedJobGroup._id); // 수정 api 요청시에는 _id를 사용
+          }
         }
       } catch (error) {
         alert("포트폴리오 데이터를 불러오는데 실패했습니다.");
@@ -258,6 +265,7 @@ const EditPortfolioPage = () => {
         <div className="editor">
           <MyCKEditor
             onChange={(content: string) => handleInputChange("contents", content)}
+            onReady={editor => setEditorInstance(editor)}
             initialContent={formData.contents}
           />
         </div>

--- a/src/pages/EditPortfolio/MyCKEditor/MyCKEditor.tsx
+++ b/src/pages/EditPortfolio/MyCKEditor/MyCKEditor.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef } from "react";
 import { CKEditor } from "@ckeditor/ckeditor5-react";
-// import { Editor as CKEditorType } from "@ckeditor/ckeditor5-core";
 
 import "./MyCKEditor.css";
 import "ckeditor5/ckeditor5.css";
@@ -44,28 +43,21 @@ import {
 import translations from "ckeditor5/translations/ko.js";
 
 interface MyCKEditorProps {
-  onChange?: (content: string) => void;
+  onChange: (content: string) => void;
+  onReady: (editor: any) => void;
   initialContent?: string;
 }
 
-const MyCKEditor = ({ onChange, initialContent }: MyCKEditorProps) => {
+const MyCKEditor = ({ onChange, onReady, initialContent }: MyCKEditorProps) => {
   const editorContainerRef = useRef(null);
   const editorRef = useRef(null);
   const [isLayoutReady, setIsLayoutReady] = useState(false);
-  // const [editorInstance, setEditorInstance] = useState<CKEditorType | null>(null);
 
   useEffect(() => {
     setIsLayoutReady(true);
 
     return () => setIsLayoutReady(false);
   }, []);
-
-  // initialContent가 변경될 때 에디터 내용 업데이트
-  // useEffect(() => {
-  //   if (editorInstance && initialContent !== undefined) {
-  //     editorInstance.setData(initialContent);
-  //   }
-  // }, [initialContent, editorInstance]);
 
   const editorConfig = {
     toolbar: {
@@ -237,12 +229,12 @@ const MyCKEditor = ({ onChange, initialContent }: MyCKEditorProps) => {
                     }
                     // console.log(data);
                   }}
-                  // onReady={editor => {
-                  //   setEditorInstance(editor);
-                  //   if (initialContent) {
-                  //     editor.setData(initialContent);
-                  //   }
-                  // }}
+                  onReady={editor => {
+                    onReady(editor);
+                    if (initialContent) {
+                      editor.setData(initialContent);
+                    }
+                  }}
                 />
               )}
             </div>

--- a/src/pages/EditPortfolio/MyCKEditor/MyCKEditor.tsx
+++ b/src/pages/EditPortfolio/MyCKEditor/MyCKEditor.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { CKEditor } from "@ckeditor/ckeditor5-react";
+import { Editor as CKEditorType } from "@ckeditor/ckeditor5-core";
 
 import "./MyCKEditor.css";
 import "ckeditor5/ckeditor5.css";
@@ -44,7 +45,7 @@ import translations from "ckeditor5/translations/ko.js";
 
 interface MyCKEditorProps {
   onChange: (content: string) => void;
-  onReady: (editor: any) => void;
+  onReady: (editor: CKEditorType) => void;
   initialContent?: string;
 }
 


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
수정 시 에디터 내용 불러오기&작성 버그 수정
CKEditor와 HTMLReactParser의 스타일 불일치 문제해결

## 📌 이슈 넘버
 
- #87 

## 📝 작업 내용

이슈에 적어둔대로,
포트폴리오 수정 시 에디터 내용 안불러와지던거 해결했고
생성/ 수정시 작성 버그(새로 입력하는 내용이 맨 앞으로 계속 추가되는 버그) 해결했습니다.

+) CKEditor와 HTMLReactParser의 스타일 불일치 문제  해결했습니다! 디테일페이지에서도 ckeditor style 적용했습니다.


----------------------------------------------------------------------------
(해결됨)
새로 반영하면 좋을점은,
현재 작성 페이지에서 보이는 작성 내용들이랑 디테일 페이지에서 보이는 내용이랑 **같은 데이터임에도 불구하고 화면상 보이는게 다른데**,
이 부분을 좀 디테일페이지에서 파싱되는 방식이나 content 가져와지는 방식 / 작성 페이지의 에디터 안에서 보이는 방식을 살펴봐야할거같네요.

작성페이지의 에디터 안에서는 이렇게 보이는데, 
![image](https://github.com/user-attachments/assets/f0123e3b-72ff-4607-965a-7b9e33446c4d)
디테일 페이지에서는 아래처럼 보입니다.
![image](https://github.com/user-attachments/assets/37f1d351-b582-470b-8359-611729a17759)
 

## 📸 스크린샷(선택)
디테일페이지에서도 ckeditor style 적용
![image](https://github.com/user-attachments/assets/27113c82-840f-4c2c-a43c-06998fb78f95)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
