### PR TITLE
[FEAT] 유저 프로필 업로드 API 구현

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -27,7 +27,8 @@ const api = ky.create({
           const token = localStorage.getItem("token");
           if (token) {
             localStorage.removeItem("token");
-            alert("만료되거나 잘못된 토큰입니다.");
+            alert("잘못된 혹은 만료된 토큰입니다.");
+            window.location.href = "/login";
           }
         }
       },

--- a/src/api/upload-single-img.ts
+++ b/src/api/upload-single-img.ts
@@ -21,3 +21,21 @@ export const uploadTumbnailImg = async (
     throw error;
   }
 };
+
+export const uploadProfileImg = async (img: File): Promise<string | undefined> => {
+  const formData = new FormData();
+  formData.append("image", img);
+  try {
+    const response = await api
+      .post(`users/upload?usage=profile`, {
+        body: formData,
+      })
+      .json<PortfolioThumbnailResType>();
+
+    if (response.success) return response.data?.url;
+    throw new Error(response.error);
+  } catch (error) {
+    console.error("단일 이미지 업로드 오류:", error);
+    throw error;
+  }
+};

--- a/src/pages/EditProfile/EditProfilePage.tsx
+++ b/src/pages/EditProfile/EditProfilePage.tsx
@@ -34,11 +34,11 @@ import { GithubUserProfileResType, UserProfileResType } from "../../types/api-ty
 import { JobGroupType } from "../../types/api-types/JobGroup";
 
 //api
-// import { uploadSingleImg } from "../../api/upload-single-img";
 import { createProfile, modifyProfile } from "../../api/create-profile";
 import { getJobGroup } from "../../api/get-job-group";
 import { getTechStacks } from "../../api/get-tech-stacks";
 import { getMyProfile } from "../../api/get-user-profile";
+import { uploadProfileImg } from "../../api/upload-single-img";
 
 /**
  * todo
@@ -209,7 +209,7 @@ const EditProfilePage: React.FC = () => {
     }
 
     if (profileImage) {
-      // profileImgUrl = (await uploadSingleImg(profileImage)) ?? "";
+      profileImgUrl = (await uploadProfileImg(profileImage)) ?? "";
 
       setUserInfo(prev => {
         return { ...prev, profileImage: profileImgUrl };

--- a/src/pages/login/GithubLoginBtn/GithubLoginBtn.tsx
+++ b/src/pages/login/GithubLoginBtn/GithubLoginBtn.tsx
@@ -7,16 +7,14 @@ interface loginResponse {
 
 const GithubLoginBtn = () => {
   return (
-    <GithubLoginBtnStylesWrapper>
+    <GithubLoginBtnStylesWrapper
+      onClick={async () => {
+        const data = await api("auth/github").json<loginResponse>();
+        window.location.href = data.redirect;
+      }}
+    >
       <img src="/github-icon.svg" alt="" />
-      <i
-        onClick={async () => {
-          const data = await api("auth/github").json<loginResponse>();
-          window.location.href = data.redirect;
-        }}
-      >
-        GitHub로 로그인하기
-      </i>
+      <i>GitHub로 로그인하기</i>
     </GithubLoginBtnStylesWrapper>
   );
 };


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
유저 프로필 업로드 API 구현
## 📌 이슈 넘버
- #96 

## 📝 작업 내용
### 1. 유저 프로필 업로드 API 구현
### 2. 401 에러시 토큰 만료 에러 메세지와 함께 로그인 페이지 이동
### 3. Github 로그인 버튼 클릭 영역 확대

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
