### PR TITLE
[FIX] 포폴 삭제 에러 수정

### DIFF
--- a/src/pages/Detail/DetailPage.tsx
+++ b/src/pages/Detail/DetailPage.tsx
@@ -34,6 +34,7 @@ import Modal from "../../components/Modal/Modal";
 import { DetailPortfolioType, PortfolioResType } from "../../types/api-types/PortfolioType";
 import { CommentApiResType, CommentResType } from "../../types/api-types/CommentType";
 import userApi from "../../api/index";
+import { deletePortfolio } from "../../api/delete-portfolio";
 import { UserApiResType, UserProfileResType } from "../../types/api-types/UserType";
 import { useNavigate, useParams } from "react-router-dom";
 import useStoreSearchPage from "../../store/store-search-page";
@@ -191,22 +192,20 @@ const DetailPage: React.FC = () => {
   }, [comments]);
 
   // 포트폴리오 삭제
-  const handlePortfolioDelete = () => {
+  const handlePortfolioDelete = async () => {
     setIsPortfolioModalOpen(false);
-    const deletePortfolio = async () => {
-      try {
-        if (!portfolioData?._id) {
-          throw new Error("Portfolio ID is missing");
-        }
-
-        const response = await userApi.delete(`/portfolios/${portfolioData._id}`).json();
-        return response;
-      } catch (error) {
-        console.error("포폴 삭제 중 에러 발생:", error);
-        throw error;
+    try {
+      if (!portfolioData?._id) {
+        throw new Error("Portfolio ID is missing");
       }
-    };
-    deletePortfolio();
+      const response = await deletePortfolio(portfolioData?._id);
+      alert("포트폴리오가 삭제되었습니다. 이전페이지로 이동합니다.");
+      navigate(-1); // 이전 페이지로 이동
+      return response;
+    } catch (error) {
+      console.error("포폴 삭제 중 에러 발생:", error);
+      throw error;
+    }
   };
 
   // 댓글 삭제


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
포폴 삭제 에러 수정

## 📌 이슈 넘버

- #102 

## 📝 작업 내용
포트폴리오 삭제 api(deletePortfolio) 만들어둔게 있어서 그거 이용하여 삭제했습니다.

그리고 삭제 후 로직이 없어서 제가 임의로
api에서 삭제 성공 시 -> 'alert("포트폴리오가 삭제되었습니다. 이전페이지로 이동합니다.")" 경고창 뜨고 -> 이전페이지로 이동
으로 설정해주었습니다.


## 💬리뷰 요구사항(선택)

삭제 후 이전페이지로 이동이 괜찮을까요? 일단 이전페이지 이동이 맞을거같아서 그렇게 해두었고
alert대신 모달 사용할까 하다가 ..  일단 alert로 했습니다.(나중에 모달로 바꿔봐도 될거같아요~)
