### PR TITLE
[REFACTOR] 디테일 페이지 기술스택 개수 제한 삭제 및 스타일 리팩토링

### DIFF
--- a/src/components/LikesAndViews/LikesAndViews.style.tsx
+++ b/src/components/LikesAndViews/LikesAndViews.style.tsx
@@ -7,6 +7,7 @@ export const StatsWrapper = styled.div`
   font-weight: ${({ theme }) => theme.FONT_WEIGHT.THICKER};
   font-size: ${({ theme }) => theme.FONT_SIZE.DESCRIPTION};
   color: #7c8484;
+  padding-top: 0.75rem;
 
   > span {
     gap: 2px;

--- a/src/components/LikesAndViews/LikesAndViews.tsx
+++ b/src/components/LikesAndViews/LikesAndViews.tsx
@@ -6,7 +6,7 @@ import commentImg from "../../assets/comment.svg";
 interface LikesAndViewsProps {
   views: number;
   likes: number;
-  comments: number;
+  comments?: number;
 }
 
 const LikesAndViews: React.FC<LikesAndViewsProps> = ({ views, likes, comments }) => {
@@ -18,10 +18,12 @@ const LikesAndViews: React.FC<LikesAndViewsProps> = ({ views, likes, comments })
       <span>
         <img src={likeImg} alt="좋아요" /> {likes}
       </span>
-      <span>
-        <img src={commentImg} alt="" />
-        {comments}
-      </span>
+      {comments && (
+        <span>
+          <img src={commentImg} alt="" />
+          {comments}
+        </span>
+      )}
     </StatsWrapper>
   );
 };

--- a/src/components/LikesAndViews/LikesAndViews.tsx
+++ b/src/components/LikesAndViews/LikesAndViews.tsx
@@ -1,13 +1,15 @@
 import { StatsWrapper } from "./LikesAndViews.style";
 import viewImg from "../../assets/view.svg";
 import likeImg from "../../assets/like.svg";
+import commentImg from "../../assets/comment.svg";
 
 interface LikesAndViewsProps {
   views: number;
   likes: number;
+  comments: number;
 }
 
-const LikesAndViews: React.FC<LikesAndViewsProps> = ({ views, likes }) => {
+const LikesAndViews: React.FC<LikesAndViewsProps> = ({ views, likes, comments }) => {
   return (
     <StatsWrapper>
       <span>
@@ -15,6 +17,10 @@ const LikesAndViews: React.FC<LikesAndViewsProps> = ({ views, likes }) => {
       </span>
       <span>
         <img src={likeImg} alt="좋아요" /> {likes}
+      </span>
+      <span>
+        <img src={commentImg} alt="" />
+        {comments}
       </span>
     </StatsWrapper>
   );

--- a/src/pages/Detail/DetailPage.styles.ts
+++ b/src/pages/Detail/DetailPage.styles.ts
@@ -72,19 +72,6 @@ export const StatsAndTags = styled.div`
   }
 `;
 
-export const CommentImage = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-weight: ${({ theme }) => theme.FONT_WEIGHT.THICKER};
-  color: #7c8484;
-  margin-left: 4px;
-
-  img {
-    margin-right: 4px;
-  }
-`;
-
 export const LinksSection = styled.section``;
 
 export const Link = styled.div`

--- a/src/pages/Detail/DetailPage.styles.ts
+++ b/src/pages/Detail/DetailPage.styles.ts
@@ -61,10 +61,12 @@ export const Title = styled.div`
 export const StatsAndTags = styled.div`
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
 
-  > div {
+  & > div:first-child {
+    flex: 1;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: ${({ theme }) => theme.PADDINGS.X_SMALL};
   }

--- a/src/pages/Detail/DetailPage.styles.ts
+++ b/src/pages/Detail/DetailPage.styles.ts
@@ -63,7 +63,7 @@ export const StatsAndTags = styled.div`
   justify-content: space-between;
   align-items: flex-start;
 
-  & > div:first-child {
+  & > div:first-of-type {
     flex: 1;
     display: flex;
     flex-wrap: wrap;

--- a/src/pages/Detail/DetailPage.tsx
+++ b/src/pages/Detail/DetailPage.tsx
@@ -23,7 +23,6 @@ import TechStack from "../../components/TechStack/TechStack";
 import Tag from "../../components/Tag/Tag";
 // import { techStacks, dummyTags2, links, dummyContents, dummyComments } from "../../data/dummyData";
 import LikesAndViews from "../../components/LikesAndViews/LikesAndViews";
-import comment from "../../assets/comment.svg";
 import link from "../../assets/link.svg";
 import HTMLReactParser from "html-react-parser/lib/index";
 import DetailPageButton from "../../components/DetailPageButton/DetailPageButton";
@@ -317,15 +316,13 @@ const DetailPage: React.FC = () => {
         <StatsAndTags>
           <div>
             {portfolioData?.techStack
-              ? portfolioData.techStack
-                  .slice(0, 3)
-                  .map(techStack => (
-                    <TechStack
-                      key={techStack.skill}
-                      content={{ ...techStack }}
-                      onClick={() => handleTechStackClick(techStack)}
-                    />
-                  ))
+              ? portfolioData.techStack.map(techStack => (
+                  <TechStack
+                    key={techStack.skill}
+                    content={{ ...techStack }}
+                    onClick={() => handleTechStackClick(techStack)}
+                  />
+                ))
               : ""}
             {portfolioData?.tags?.map((tag, i) => (
               <Tag key={i} content={tag} onClick={() => handleTagClick(tag)} />
@@ -333,14 +330,14 @@ const DetailPage: React.FC = () => {
           </div>
           <div>
             {portfolioData ? (
-              <LikesAndViews views={portfolioData?.view} likes={likeCount || 0} />
+              <LikesAndViews
+                views={portfolioData?.view}
+                likes={likeCount || 0}
+                comments={totComment || 0}
+              />
             ) : (
               ""
             )}
-            <CommentImage>
-              <img src={comment} alt="" />
-              {totComment}
-            </CommentImage>
           </div>
         </StatsAndTags>
       </UserProfileSection>

--- a/src/pages/Detail/DetailPage.tsx
+++ b/src/pages/Detail/DetailPage.tsx
@@ -6,7 +6,6 @@ import {
   UserImage,
   Title,
   StatsAndTags,
-  CommentImage,
   LinksSection,
   Link,
   ContentSection,


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
- 디테일 페이지 기술스택 개수 제한 삭제 및 스타일 리팩토링

## 📌 이슈 넘버
- #105 


## 📝 작업 내용
**1. 기술스택 개수 제한 해제** 
**`DetailPage.tsx`**
```javascript
//before
portfolioData.techStack.slice(0,3).map( .... );

//after
portfolioData.techStack.map( ... );
```
**2. LikesAndViews 컴포넌트와 댓글 수 컴포넌트 병합**
`{ likes, views }` => `{ likes, views, comments }`

**3. 스타일 수정**
- 기술스택 목록에 `flex-wrap` 적용
- LikesAndViews 컴포넌트에 `top-padding : 0.75rem` 적용

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
